### PR TITLE
optimize aggregation memory: replace maxBy with pre-sort + first()

### DIFF
--- a/.changeset/optimize-aggregate-memory.md
+++ b/.changeset/optimize-aggregate-memory.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': patch
+---
+
+Optimize clonotype aggregation memory: replace maxBy (top_k_by) with pre-sort + first() to enable streaming-compatible group_by in Polars

--- a/workflow/src/aggregate-by-clonotype-key.tpl.tengo
+++ b/workflow/src/aggregate-by-clonotype-key.tpl.tengo
@@ -78,6 +78,12 @@ self.body(func(inputs) {
 		currentDf = pt.concat(dataFrames)
 	}
 
+	// Pre-sort by abundance descending so that first() in the aggregation picks values
+	// from the max-abundance row. This replaces N separate maxBy (top_k_by) aggregations
+	// with N first() aggregations, which are streaming-compatible in Polars and use O(1)
+	// state per group instead of buffering all rows — dramatically reducing memory usage.
+	currentDf = currentDf.sort([mainAbundanceColumnNormalized], {descending: true})
+
 	aggExpressions := []
 	hasFractionCDRMutations := false
 
@@ -90,7 +96,7 @@ self.body(func(inputs) {
 			continue
 		}
 		aggExpressions = append(aggExpressions,
-			pt.col(colDef.column).maxBy(pt.col(mainAbundanceColumnNormalized)).alias(colDef.column)
+			pt.col(colDef.column).first().alias(colDef.column)
 		)
 	}
 


### PR DESCRIPTION
All maxBy aggregations use the same `by` expression (abundance), so they all select values from the same row per group. Pre-sorting by abundance descending and using first() is semantically equivalent but allows Polars' streaming group_by to use O(1) state per group instead of buffering all rows for top_k_by — expected 10-20x memory reduction for large datasets.