### PR TITLE
Fix cross-project deduplication for aggregation and QC report

### DIFF
--- a/.changeset/dedup-fixes.md
+++ b/.changeset/dedup-fixes.md
@@ -1,0 +1,12 @@
+---
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': minor
+'@platforma-open/milaboratories.mixcr-amplicon-alignment': minor
+---
+
+Fix cross-project deduplication for aggregation and QC report
+
+- Add `anonymize: true` to aggregation processColumn (sample IDs no longer break CID)
+- Anonymize QC report inputs and deanonymize output TSV (structural render deduplicates, ephemeral deanonymization per project)
+- Pass `perProcessMemGB` as metaInput to QC report render (excluded from CID)
+- Move `xsv.importFile` for QC report to caller with proper column specs
+- Add `hash_override` to mixcr-export, aggregate-by-clonotype-key, export-report, repseqio-library templates

--- a/workflow/src/aggregate-by-clonotype-key.tpl.tengo
+++ b/workflow/src/aggregate-by-clonotype-key.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override 6C6DD74F-A89C-4CBE-AEB9-B26E40A07FDF
+
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")

--- a/workflow/src/deanonymization.tpl.tengo
+++ b/workflow/src/deanonymization.tpl.tengo
@@ -1,0 +1,70 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+smart := import("@platforma-sdk/workflow-tengo:smart")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+maps := import("@platforma-sdk/workflow-tengo:maps")
+
+self.defineOutputs("deanonimizedTsv")
+
+self.awaitState("clusteringResult", "ResourceReady")
+self.awaitState("mapping", "ResourceReady")
+
+/**
+ * Builds a when/then/otherwise expression to replace values in a column based on a mapping.
+ * @param colExpr - pt column expression
+ * @param mapping - map from anonymized values (oldVal) to original values (newVal)
+ * @returns pt expression with value replacements
+ */
+buildReplaceExpression := func(colExpr, mapping) {
+	if len(mapping) == 0 {
+		return colExpr
+	}
+
+	whenExpr := undefined
+	maps.forEach(mapping, func(oldVal, newVal) {
+		condition := colExpr.eq(pt.lit(oldVal))
+		if is_undefined(whenExpr) {
+			whenExpr = pt.when(condition).then(pt.lit(newVal))
+		} else {
+			whenExpr = whenExpr.when(condition).then(pt.lit(newVal))
+		}
+	})
+
+	return whenExpr.otherwise(colExpr)
+}
+
+self.body(func(args) {
+	// Get mapping JSON
+	mappingJson := undefined
+	if smart.isResource(args.mapping) {
+		mappingJson = args.mapping.getDataAsJson()
+	} else if is_map(args.mapping) {
+		mappingJson = args.mapping
+	} else {
+		mappingResource := smart.resource(args.mapping)
+		mappingJson = mappingResource.getDataAsJson()
+	}
+
+	// Process TSV file
+	deanonimizedTsv := args.clusteringResult
+	if !is_undefined(deanonimizedTsv) {
+		wf := pt.workflow().mem("8GiB").cpu(2)
+
+		df := wf.frame(deanonimizedTsv, {
+			xsvType: "tsv",
+			inferSchema: false
+		})
+
+		// Replace anonymized sampleId values with real ones
+		df = df.withColumns(
+			buildReplaceExpression(pt.col("sampleId"), mappingJson).alias("sampleId")
+		)
+
+		df.save("result.tsv")
+		ptResult := wf.run()
+		deanonimizedTsv = ptResult.getFile("result.tsv")
+	}
+
+	return {
+		deanonimizedTsv: deanonimizedTsv
+	}
+})

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override D26E7099-3166-44C4-B80D-6AD1535E8258
+
 self := import("@platforma-sdk/workflow-tengo:tpl")
 smart := import("@platforma-sdk/workflow-tengo:smart")
 ll := import("@platforma-sdk/workflow-tengo:ll")
@@ -7,16 +9,14 @@ pcolumn := import("@platforma-sdk/workflow-tengo:pframes.pcolumn")
 times := import("times")
 text := import("text")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
-xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 pt := import("@platforma-sdk/workflow-tengo:pt")
-qcReportColumns := import(":qc-report-columns")
 
 math := import("math")
 json := import("json")
 
-self.defineOutputs("qcReportTable")
+self.defineOutputs("rawTsv")
 
 mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:main")
 ptablerSw := assets.importSoftware("@platforma-open/milaboratories.software-ptabler:main")
@@ -335,18 +335,7 @@ self.body(func(inputs) {
     
     tsvFile := wfResult.getFile("qc-report-processed.tsv")
 
-    qcReportColumns := qcReportColumns(hasUmi, sampleIdAxisSpec, chains, umiTags)
-    reportColumnsSpec := qcReportColumns.reportColumnsSpec
-
-    qcReportTable := xsv.importFile(
-		tsvFile,
-		"tsv",
-		reportColumnsSpec,
-		{ cpu: 1, mem: "16GiB" }
-	)
-
-    
     return {
-        qcReportTable: qcReportTable
+        rawTsv: tsvFile
     }
 })

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override 1B5A50CA-7229-4284-BF1D-8044CFC2F68E
+
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -8,6 +8,8 @@ assets := import("@platforma-sdk/workflow-tengo:assets")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 maps := import("@platforma-sdk/workflow-tengo:maps")
+anonymize := import("@platforma-sdk/workflow-tengo:anonymize")
+xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 
 math := import("math")
 json := import("json")
@@ -17,7 +19,9 @@ mixcrAnalyzeTpl := assets.importTemplate(":mixcr-analyze")
 mixcrExportTpl := assets.importTemplate(":mixcr-export")
 aggregateByClonotypeKeyTpl := assets.importTemplate(":aggregate-by-clonotype-key")
 exportReportTpl := assets.importTemplate(":export-report")
+deanonymizationTpl := assets.importTemplate(":deanonymization")
 calculateExportSpecs := import(":calculate-export-specs")
+qcReportColumnsLib := import(":qc-report-columns")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -330,7 +334,7 @@ self.body(func(inputs) {
 		aggregateByClonotypeKeyTpl,
 		aggregationOutputs,
 		{
-			aggregate: ["pl7.app/sampleId"],
+			aggregate: [{ name: "pl7.app/sampleId", anonymize: true }],
 			traceSteps: [{type: "milaboratories.mixcr-amplicon-alignment.aggregate", id: blockId + "." + chains, importance: 150, label: "Aggregate " + chains}],
 
 			extra: {
@@ -353,20 +357,49 @@ self.body(func(inputs) {
 	exportResults.addXsvOutputToBuilder(clones, "byCloneKeyBySample", "clonotypeProperties/bySample/" + chains + "/")
 	aggregationResults.addXsvOutputToBuilder(clones, "aggregates", "clonotypeProperties/aggregates/" + chains + "/")
 
-	qcReportTable := render.create(exportReportTpl, {
+	// Anonymize sample-keyed ResourceMaps for QC report dedup across projects
+	anonResult := anonymize.anonymizePKeys({
 		clnsData: mixcrResults.outputData("clns"),
+		clonotypeTablesData: clonotypeTablesData[chains]
+	}, [0])
+
+	anonClonotypeTablesData := {}
+	anonClonotypeTablesData[chains] = anonResult.result["clonotypeTablesData"]
+
+	// Structural render — deduplicates across projects
+	// perProcessMemGB passed as metaInput (excluded from CID, but available for exportClones memory)
+	qcReportRender := render.create(exportReportTpl, {
+		clnsData: anonResult.result["clnsData"],
+		clonotypeTablesData: anonClonotypeTablesData,
 		sampleIdAxisSpec: sampleIdAxisSpec,
 		chains: [chains],
 		library: referenceLibrary,
 		isLibraryFileGzipped: params.isLibraryFileGzipped,
-		clonotypeTablesData: clonotypeTablesData,
 		hasUmi: hasUMI,
 		umiTags: umiTags,
-		perProcessMemGB: perProcessMemGB,
 		productiveFeature: productiveFeature,
 		stopCodonTypes: params.stopCodonTypes,
 		stopCodonReplacements: params.stopCodonReplacements
+	}, {
+		metaInputs: {
+			perProcessMemGB: perProcessMemGB
+		}
 	})
+
+	// Deanonymize QC report raw TSV (restore real sampleIds via PTabler replacement)
+	deanonResult := render.createEphemeral(deanonymizationTpl, {
+		mapping: anonResult.mapping,
+		clusteringResult: qcReportRender.output("rawTsv")
+	})
+
+	// Import deanonymized TSV into PFrame
+	qcReportColumns := qcReportColumnsLib(hasUMI, sampleIdAxisSpec, [chains], umiTags)
+	qcReportTable := xsv.importFile(
+		deanonResult.output("deanonimizedTsv"),
+		"tsv",
+		qcReportColumns.reportColumnsSpec,
+		{ cpu: 1, mem: "16GiB" }
+	)
 
 	return {
 		"qc.spec": mixcrResults.outputSpec("qc"),
@@ -385,6 +418,6 @@ self.body(func(inputs) {
 
 		clones: clones.build(),
 		clonotypeTables: clonotypeTables.build(),
-		qcReportTable: qcReportTable.output("qcReportTable")
+		qcReportTable: qcReportTable
 	}
 }) 

--- a/workflow/src/repseqio-library.tpl.tengo
+++ b/workflow/src/repseqio-library.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override F6498F99-758C-4F28-B59D-31F11EB6C8A5
+
 // repseqio-library template for generating reference library from V and J FASTA files
 
 self := import("@platforma-sdk/workflow-tengo:tpl")


### PR DESCRIPTION
## Summary
- Add `anonymize: true` to aggregation processColumn — sample IDs no longer break CID-based dedup across projects
- Anonymize QC report inputs (`clnsData`, `clonotypeTablesData`) before structural `render.create`; deanonymize output TSV via ephemeral PTabler — heavy QC computation deduplicates, only lightweight deanonymization re-runs per project
- Pass `perProcessMemGB` as `metaInput` to QC report render (excluded from CID but available for `mixcr exportClones` memory allocation)
- Add `hash_override` to 4 structural templates (`mixcr-export`, `aggregate-by-clonotype-key`, `export-report`, `repseqio-library`) for cross-version dedup stability

## Test plan
- [x] All 35 tests pass (including `simple project`, `FR2:FR4 with imputation`, `CDR1:CDR3 without imputation`)
- [x] Build succeeds