### PR TITLE
Fix referenceLibrary.json permission-denied on localfs backend

### DIFF
--- a/.changeset/fix-reference-library-permission-denied.md
+++ b/.changeset/fix-reference-library-permission-denied.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': patch
+---
+
+Fix `FileNotFoundException: referenceLibrary.json (Permission denied)` when running on the localfs backend. The reference-library workflow invoked `repseqio inferPoints` and `repseqio compile` with the same path for input and output (`referenceLibrary.json`). On localfs, input files are mounted read-only, so the tool could read them but the final write back failed. The output is now written to a separate file (`referenceLibrary.out.json`).

--- a/workflow/src/repseqio-library.tpl.tengo
+++ b/workflow/src/repseqio-library.tpl.tengo
@@ -74,13 +74,13 @@ self.body(func(inputs) {
 		arg("--force").
 		addFile("referenceLibrary.json", referenceLibrary).
 		arg("referenceLibrary.json").
-		arg("referenceLibrary.json").
-		saveFile("referenceLibrary.json").
+		arg("referenceLibrary.out.json").
+		saveFile("referenceLibrary.out.json").
 		addFile("vGene.fasta", vGeneFasta).
 		cpu(1).mem("4GB")
 	
 	repseqioInferPointsVResult := repseqioInferPointsVCmd.run()
-	referenceLibraryV := repseqioInferPointsVResult.getFile("referenceLibrary.json")
+	referenceLibraryV := repseqioInferPointsVResult.getFile("referenceLibrary.out.json")
 	
 	repseqioInferPointsJCmd := exec.builder().
 		software(repseqioSw).
@@ -90,13 +90,13 @@ self.body(func(inputs) {
 		arg("--force").
 		addFile("referenceLibrary.json", referenceLibraryV).
 		arg("referenceLibrary.json").
-		arg("referenceLibrary.json").
-		saveFile("referenceLibrary.json").
+		arg("referenceLibrary.out.json").
+		saveFile("referenceLibrary.out.json").
 		addFile("jGene.fasta", jGeneFasta).
 		cpu(1).mem("4GB")
 	
 	repseqioInferPointsJResult := repseqioInferPointsJCmd.run()
-	referenceLibraryJ := repseqioInferPointsJResult.getFile("referenceLibrary.json")
+	referenceLibraryJ := repseqioInferPointsJResult.getFile("referenceLibrary.out.json")
 
 	repseqioCompileCmd := exec.builder().
 		software(repseqioSw).
@@ -104,14 +104,14 @@ self.body(func(inputs) {
 		arg("--force").
 		addFile("referenceLibrary.json", referenceLibraryJ).
 		arg("referenceLibrary.json").
-		arg("referenceLibrary.json").
-		saveFile("referenceLibrary.json").
+		arg("referenceLibrary.out.json").
+		saveFile("referenceLibrary.out.json").
 		addFile("vGene.fasta", vGeneFasta).
 		addFile("jGene.fasta", jGeneFasta).
 		cpu(1).mem("4GB")
 	
 	repseqioCompileResult := repseqioCompileCmd.run()
-	referenceLibraryCompiled := repseqioCompileResult.getFile("referenceLibrary.json")
+	referenceLibraryCompiled := repseqioCompileResult.getFile("referenceLibrary.out.json")
 	
 	repseqioDebugCmd := exec.builder().
 		software(repseqioSw).


### PR DESCRIPTION
## Summary
- `repseqio inferPoints` (V and J) and `repseqio compile` were called with the same path `referenceLibrary.json` for both input and output. On the localfs backend input files are mounted read-only, so the JVM read the file fine but failed to open it for writing — `FileNotFoundException: referenceLibrary.json (Permission denied)`. This broke the Amplicon Alignment block end-to-end on localfs.
- Each step now writes to `referenceLibrary.out.json` and feeds that into the next step (still mounted as `referenceLibrary.json` input). No tool changes required.

Fixes the bug reported in MILAB-6242.

## Test plan
- [ ] Run Amplicon Alignment block on a localfs backend (3.4.1) with a tiny dataset (e.g. tiny-trees bulk) and verify the reference-library template completes without `Permission denied`.
- [ ] Confirm downstream alignment steps still receive a valid compiled `referenceLibrary.json` (no breakage in `mixcr-analyze`).