### PR TITLE
Disable low quality mapping

### DIFF
--- a/.changeset/deep-buckets-crash.md
+++ b/.changeset/deep-buckets-crash.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow": patch
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.model": patch
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.ui": patch
+---
+
+Add an option to disable low-quality read mapping

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -59,6 +59,7 @@ export interface BlockArgs {
   cloneClusteringMode?: CloneClusteringMode; // default: 'off'
   assemblingFeature?: AssemblingFeature; // default: 'VDJRegion'
   badQualityThreshold?: number; // default: 15 (MiXCR default)
+  disableLowQualityMapping?: boolean; // default: false; when true, passes maxBadPointsPercent=0 to MiXCR to skip the deferred-reads mapping phase
   stopCodonTypes?: StopCodonType[];
   stopCodonReplacements?: StopCodonReplacements;
   referenceFileHandle?: ImportFileHandle;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^2.5.0-13-master
       version: 2.5.0-25-master
     '@platforma-sdk/block-tools':
-      specifier: 2.7.13
-      version: 2.7.13
+      specifier: 2.8.0
+      version: 2.8.0
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -94,7 +94,7 @@ importers:
         version: 2.29.8(@types/node@25.0.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.0
       turbo:
         specifier: 'catalog:'
         version: 2.7.5
@@ -116,7 +116,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.0
 
   model:
     dependencies:
@@ -135,7 +135,7 @@ importers:
         version: 1.2.2
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.0
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -971,8 +971,8 @@ packages:
     resolution: {integrity: sha512-lKzbuUJHBiGEVxqS9+EaYkuMAQt0iAohQUiIviu+2rNZHrTIvJGLBIiLBHC7fmjJM45xCKzyLG6c0tPjDUi2kQ==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
   '@milaboratories/pf-driver@1.1.1':
@@ -997,6 +997,10 @@ packages:
     resolution: {integrity: sha512-a+Vm+j2WuQ+aSSbOsHkBKiHEIjRpBFNWom830oMqXPX8D6y2OLkU+mcP8vXNnf+0tHQASydh1YYqKAHEdxLfyQ==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.7.0':
+    resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.7.15':
     resolution: {integrity: sha512-XYkyYdoPFGtxIVogCmQ6tGupUBoi1gtfLnTdd/i8Qqfnk/P673hr8TTH+CBAglqNbrg+jubw4oYO4cLpGIEzfA==}
 
@@ -1007,6 +1011,9 @@ packages:
   '@milaboratories/pl-drivers@1.12.2':
     resolution: {integrity: sha512-5ivviwrJUumo7Q8DssGhkfhl4ampet10IBIGQIyui1mMCDsR1Wc31ggnsHISr/EHpgMj0SNahk7uzjQR4SRu2g==}
     engines: {node: '>=22'}
+
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
@@ -1027,6 +1034,9 @@ packages:
   '@milaboratories/pl-model-backend@1.2.1':
     resolution: {integrity: sha512-5TGyJhCoAjog9cswXLaIY3PTap5QRSQK/m+P+GIoCBSyqhsMY9FGPfk3s+oEh42N6W48KUP0/gTTCCKv3mzLLQ==}
 
+  '@milaboratories/pl-model-backend@1.3.0':
+    resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+
   '@milaboratories/pl-model-common@1.23.0':
     resolution: {integrity: sha512-1uHb2pS+hWJyBKvfOlMYmjbFuWn+tNOULWj84mWASdqSjdYyHfVYbLq5esawM+dnZ2GBQIzJRbXrZYIMqH4Peg==}
 
@@ -1036,8 +1046,8 @@ packages:
   '@milaboratories/pl-model-common@1.28.0':
     resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
 
-  '@milaboratories/pl-model-common@1.35.0':
-    resolution: {integrity: sha512-IQ/49eFUNl2hnI83Zj9WqxKhEYCmw9TZKwX4yVdzh+6zKY6oPWKo6T4Y/g7oPsy94WA+yJGcN7o8wN0M7y005Q==}
+  '@milaboratories/pl-model-common@1.42.0':
+    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
   '@milaboratories/pl-model-middle-layer@1.13.0':
     resolution: {integrity: sha512-FBgu0rdUoXcDMzjrgLXUdwRJtyv5BKLHgJ2fVwtDapjGCWxmLzeW7QeFo+VpLJPimxnuOXoZBxFcn7p1gfZuLQ==}
@@ -1045,8 +1055,8 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.4':
-    resolution: {integrity: sha512-wn4J8wELpI8nV2yzeeoiDvX5Riz4vnvE9/98m9dBvowDhYRmdBralInPYQkX1do8jGmqlwLMRx9KNV+X4ugQMw==}
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
   '@milaboratories/pl-tree@1.9.2':
     resolution: {integrity: sha512-U2FZ5B0G3kRFXNz1RWq7OmWSHcuBL+KUxfQT8DphYZJ9B3gB4OpMGuhFWYkn4/SZDv9o0zgQIjdaYQYr3krCZw==}
@@ -1082,15 +1092,15 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.38':
     resolution: {integrity: sha512-acc/gmGKtpg5fUhNoPXoYh+rcKzl7KoXOa9JWyNpvXcKirx1Q6+Cc14OdlbbxxUOS9P+5cLKW1youkLuT/jemQ==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.40':
-    resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
 
   '@milaboratories/ts-helpers@1.7.3':
     resolution: {integrity: sha512-65/URvZfb5moAyIaRKoExjam5ZcXHg9EyepFU7dnUBpPaW0q5+HTS6ThQDIiGJk63qwXe9qyyDgIbSqyhFWulw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ts-helpers@1.8.1':
-    resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.11.1':
@@ -1430,8 +1440,8 @@ packages:
     resolution: {integrity: sha512-1U99O9OcZugrsnIt9WtAFbUxBmbBlEKf57T3haLqulqrAjhXOmK1JTPx/jvZJDbJOCCeIJKeD3EWinrhRFswfw==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.7.13':
-    resolution: {integrity: sha512-Gss2jM5UUGbm6fSpFUHqWm8u2bH7DYHIrmjS42gxgF0L+Eiori0W7LDqGnjMNZ+eH5+KEo6j+WuRBu6dIDGvyg==}
+  '@platforma-sdk/block-tools@2.8.0':
+    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -4379,6 +4389,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -5759,7 +5770,7 @@ snapshots:
 
   '@milaboratories/helpers@1.14.0': {}
 
-  '@milaboratories/helpers@1.14.1': {}
+  '@milaboratories/helpers@1.14.2': {}
 
   '@milaboratories/pf-driver@1.1.1(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
@@ -5818,6 +5829,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
+  '@milaboratories/pl-client@3.7.0':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.4
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.2
+
   '@milaboratories/pl-config@1.7.15':
     dependencies:
       '@milaboratories/ts-helpers': 1.7.3
@@ -5862,6 +5891,11 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
 
   '@milaboratories/pl-error-like@1.12.5':
     dependencies:
@@ -5928,6 +5962,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
+  '@milaboratories/pl-model-backend@1.3.0':
+    dependencies:
+      '@milaboratories/pl-client': 3.7.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.23.0':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.5
@@ -5947,10 +5987,10 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.35.0':
+  '@milaboratories/pl-model-common@1.42.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5970,10 +6010,10 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.18.4':
+  '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.35.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.43.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -6053,9 +6093,9 @@ snapshots:
       '@milaboratories/ts-helpers': 1.7.3
       '@oclif/core': 4.8.0
 
-  '@milaboratories/ts-helpers-oclif@1.1.40':
+  '@milaboratories/ts-helpers-oclif@1.1.41':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.8.0
 
   '@milaboratories/ts-helpers@1.7.3':
@@ -6063,9 +6103,9 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/ts-helpers@1.8.1':
+  '@milaboratories/ts-helpers@1.8.2':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -6455,15 +6495,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/block-tools@2.7.13':
+  '@platforma-sdk/block-tools@2.8.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.35.0
-      '@milaboratories/pl-model-middle-layer': 1.18.4
+      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.1
-      '@milaboratories/ts-helpers-oclif': 1.1.40
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
       '@oclif/core': 4.8.0
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.60.2
   '@platforma-sdk/tengo-builder': 2.5.1
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.13
+  '@platforma-sdk/block-tools': 2.8.0
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.60.2
   '@milaboratories/helpers': 1.14.0

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -15,6 +15,7 @@ import {
   PlSectionSeparator,
   PlTextArea,
   PlTextField,
+  PlTooltip,
   type ListOption,
 } from '@platforma-sdk/ui-vue';
 import { computed, ref, watch } from 'vue';
@@ -252,6 +253,13 @@ const imputeGermline = computed({
   },
 });
 
+const disableLowQualityMapping = computed({
+  get: () => app.model.args.disableLowQualityMapping ?? false,
+  set: (value: boolean) => {
+    app.model.args.disableLowQualityMapping = value;
+  },
+});
+
 const stopCodonOptions: ListOption<StopCodonType>[] = [
   { label: 'Amber (TAG)', value: 'amber' },
   { label: 'Ochre (TAA)', value: 'ochre' },
@@ -468,6 +476,15 @@ ATCGATCGATCG..."
         prevent erroneous reads from creating spurious clonotypes. Leave empty to use the MiXCR default (15).
       </template>
     </PlNumberField>
+    <PlCheckbox v-model="disableLowQualityMapping">
+      Skip low-quality read mapping
+      <PlTooltip class="info" position="top">
+        <template #tooltip>
+          Reduces memory usage on large datasets by dropping low-quality reads
+          instead of mapping them to existing clonotypes.
+        </template>
+      </PlTooltip>
+    </PlCheckbox>
     <PlNumberField
       v-model="app.model.args.limitInput"
       label="Take only this number of reads into analysis"

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -144,6 +144,7 @@ wf.body(func(args) {
 			assemblingFeature: args.assemblingFeature,
 			imputeGermline: args.imputeGermline,
 			badQualityThreshold: args.badQualityThreshold,
+			disableLowQualityMapping: args.disableLowQualityMapping,
 			isLibraryFileGzipped: isLibraryFileGzipped,
 			stopCodonTypes: args.stopCodonTypes,
 			stopCodonReplacements: args.stopCodonReplacements

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -122,6 +122,11 @@ self.body(func(inputs) {
 		mixcrCmdBuilder.arg("-Massemble.cloneAssemblerParameters.minimalQuality=" + string(int(badQualityThreshold)))
 	}
 
+	// Disable the deferred-reads mapping phase
+	if !is_undefined(params.disableLowQualityMapping) && params.disableLowQualityMapping {
+		mixcrCmdBuilder.arg("-Massemble.cloneAssemblerParameters.maxBadPointsPercent=0")
+	}
+
 		// if (!is_undefined(threePrimePrimer)) {
 		// 	mixcrCmdBuilder.arg("--floating-left-alignment-boundary")
 		// } else {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -123,7 +123,8 @@ self.body(func(inputs) {
 	}
 
 	// Disable the deferred-reads mapping phase
-	if !is_undefined(params.disableLowQualityMapping) && params.disableLowQualityMapping {
+	disableLowQualityMapping := params.disableLowQualityMapping
+	if !is_undefined(disableLowQualityMapping) && disableLowQualityMapping {
 		mixcrCmdBuilder.arg("-Massemble.cloneAssemblerParameters.maxBadPointsPercent=0")
 	}
 

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -221,6 +221,7 @@ self.body(func(inputs) {
 					assemblingFeature: params.assemblingFeature,
 					imputeGermline: params.imputeGermline,
 					badQualityThreshold: params.badQualityThreshold,
+					disableLowQualityMapping: params.disableLowQualityMapping,
 					isLibraryFileGzipped: params.isLibraryFileGzipped
 				}, { removeUndefs: true }),
 				limitInput: limitInput


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `disableLowQualityMapping` toggle that, when enabled, passes `-Massemble.cloneAssemblerParameters.maxBadPointsPercent=0` to MiXCR to skip the deferred-reads mapping phase, reducing memory usage on large datasets.

- **Model**: adds `disableLowQualityMapping?: boolean` to `BlockArgs` with a descriptive comment.
- **UI**: adds a `PlCheckbox` + `PlTooltip` control following the same computed-property pattern as `imputeGermline`.
- **Workflow**: the new param is forwarded end-to-end through `main.tpl.tengo` → `process.tpl.tengo` → `mixcr-analyze.tpl.tengo` under `removeUndefs: true`, matching how all other optional params are handled.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it adds a purely additive optional flag with correct guard conditions throughout the pipeline.

The feature is correctly wired end-to-end — model, UI, and all three workflow templates are consistent. The only note is a minor style inconsistency in `mixcr-analyze.tpl.tengo` where the new param is accessed inline rather than extracted to a local variable as every other optional param is, which slightly reduces maintainability but has no runtime impact.

workflow/src/mixcr-analyze.tpl.tengo — minor style inconsistency in how the new parameter is accessed compared to adjacent optional params like `badQualityThreshold`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds optional `disableLowQualityMapping?: boolean` field to `BlockArgs` with a clear inline comment describing its effect. |
| ui/src/pages/SettingsPanel.vue | Adds a computed binding and PlCheckbox UI control for `disableLowQualityMapping`; follows the same pattern as `imputeGermline`. First use of PlTooltip in this file — works if `class="info"` renders its own info icon trigger. |
| workflow/src/mixcr-analyze.tpl.tengo | Correctly appends `-Massemble.cloneAssemblerParameters.maxBadPointsPercent=0` when `disableLowQualityMapping` is true; minor style inconsistency in how the param is accessed compared to `badQualityThreshold`. |
| workflow/src/main.tpl.tengo | Passes `disableLowQualityMapping` through from top-level args, consistent with all other optional parameters. |
| workflow/src/process.tpl.tengo | Correctly forwards `disableLowQualityMapping` in the `maps.clone` call under `removeUndefs: true`, consistent with `badQualityThreshold` and other optional params. |
| .changeset/deep-buckets-crash.md | Changeset correctly bumps all three packages (workflow, model, ui) as patch releases. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    UI["SettingsPanel.vue\nPlCheckbox: disableLowQualityMapping"]
    MODEL["model/index.ts\nBlockArgs.disableLowQualityMapping?: boolean"]
    MAIN["main.tpl.tengo\nargs.disableLowQualityMapping"]
    PROC["process.tpl.tengo\nmaps.clone(..., removeUndefs: true)"]
    MIXCR_TPL["mixcr-analyze.tpl.tengo\nif !is_undefined && true"]
    MIXCR["-Massemble.cloneAssemblerParameters\n.maxBadPointsPercent=0"]

    UI -->|"v-model binding"| MODEL
    MODEL -->|"passed via args"| MAIN
    MAIN -->|"forwarded"| PROC
    PROC -->|"forwarded"| MIXCR_TPL
    MIXCR_TPL -->|"appends flag"| MIXCR
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
workflow/src/mixcr-analyze.tpl.tengo:126-127
**Inconsistent parameter access style**

All other optional parameters in this function are first extracted into a local variable (e.g., `badQualityThreshold := params.badQualityThreshold`) and then checked with `is_undefined`. Accessing `params.disableLowQualityMapping` inline twice breaks that pattern. If `params` is ever nil or the key layout changes, the inline double-access is harder to update consistently. Consider extracting to a local first for uniformity with the surrounding code.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6310 Disable low quality mapping"](https://github.com/platforma-open/mixcr-amplicon-alignment/commit/a44cc3321a030a67da4637ec37ae08d67e7b31f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32796086)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->