### PR TITLE
MILAB-6319: canonicalize workflow params for deterministic CIDs (block-side)

### DIFF
--- a/.changeset/cid-determinism.md
+++ b/.changeset/cid-determinism.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': patch
+'@platforma-open/milaboratories.mixcr-amplicon-alignment': patch
+---
+
+Make workflow params resources canonically encoded so cross-project deduplication of MiXCR analyze, MiXCR export, and per-clonotype aggregation runs works as intended. Tengo's stdlib `json.encode` does not sort map keys, so passing raw Tengo maps to `processColumn`'s `extra.params` (and to `smart.createJsonResource`) produces non-deterministic resource CIDs and silently defeats cross-project cache recovery. Introduce a block-local `canonical-resource.lib.tengo` helper that wraps `smart.createValueResource(RTYPE_JSON, canonical.encode(value))` and use it at each affected site. Move `referenceLibrary` out of the params map into its own input field on `mixcr-analyze` and `mixcr-export` since references cannot round-trip through JSON. Use sorted-key iteration when building codon-translation chains in `mixcr-export` and `export-report` so the emitted PTabler workflow JSON is byte-stable. Remove unused `times` imports.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^2.5.0-13-master
       version: 2.5.0-25-master
     '@platforma-sdk/block-tools':
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -94,7 +94,7 @@ importers:
         version: 2.29.8(@types/node@25.0.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       turbo:
         specifier: 'catalog:'
         version: 2.7.5
@@ -116,7 +116,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
 
   model:
     dependencies:
@@ -135,7 +135,7 @@ importers:
         version: 1.2.2
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -997,8 +997,8 @@ packages:
     resolution: {integrity: sha512-a+Vm+j2WuQ+aSSbOsHkBKiHEIjRpBFNWom830oMqXPX8D6y2OLkU+mcP8vXNnf+0tHQASydh1YYqKAHEdxLfyQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-client@3.7.0':
-    resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.7.15':
@@ -1034,8 +1034,8 @@ packages:
   '@milaboratories/pl-model-backend@1.2.1':
     resolution: {integrity: sha512-5TGyJhCoAjog9cswXLaIY3PTap5QRSQK/m+P+GIoCBSyqhsMY9FGPfk3s+oEh42N6W48KUP0/gTTCCKv3mzLLQ==}
 
-  '@milaboratories/pl-model-backend@1.3.0':
-    resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.23.0':
     resolution: {integrity: sha512-1uHb2pS+hWJyBKvfOlMYmjbFuWn+tNOULWj84mWASdqSjdYyHfVYbLq5esawM+dnZ2GBQIzJRbXrZYIMqH4Peg==}
@@ -1440,8 +1440,8 @@ packages:
     resolution: {integrity: sha512-1U99O9OcZugrsnIt9WtAFbUxBmbBlEKf57T3haLqulqrAjhXOmK1JTPx/jvZJDbJOCCeIJKeD3EWinrhRFswfw==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.8.0':
-    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -5829,7 +5829,7 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-client@3.7.0':
+  '@milaboratories/pl-client@3.8.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -5962,9 +5962,9 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-backend@1.3.0':
+  '@milaboratories/pl-model-backend@1.3.2':
     dependencies:
-      '@milaboratories/pl-client': 3.7.0
+      '@milaboratories/pl-client': 3.8.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6055,7 +6055,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.9
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.6.3))
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.2)(rollup@4.53.4)
       typescript: 5.9.3
@@ -6495,11 +6495,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/block-tools@2.8.0':
+  '@platforma-sdk/block-tools@2.8.2':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
@@ -9171,7 +9171,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.6.3)):
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.60.2
   '@platforma-sdk/tengo-builder': 2.5.1
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.0
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.60.2
   '@milaboratories/helpers': 1.14.0

--- a/workflow/src/canonical-resource.lib.tengo
+++ b/workflow/src/canonical-resource.lib.tengo
@@ -1,0 +1,25 @@
+smart := import("@platforma-sdk/workflow-tengo:smart")
+constants := import("@platforma-sdk/workflow-tengo:constants")
+canonical := import("@platforma-sdk/workflow-tengo:canonical")
+ll := import("@platforma-sdk/workflow-tengo:ll")
+
+// Create a JSON value resource with canonical (sorted-key) encoding.
+//
+// Use this instead of smart.createJsonResource(map) anywhere the value is
+// read as a CID input by a pure template downstream. Tengo's stdlib
+// json.encode does not sort map keys, so createJsonResource(map) on a map
+// (or array containing maps) produces non-deterministic bytes and therefore
+// a non-deterministic resource CID. See the harness reflection at
+// mictx-helper/harnesses/block-dev/_meta/reflections/processed/2026-04-29-create-json-resource-dedup-trap.md
+// for the full trap.
+//
+// Consumers read the resource through `inputs.X` as a Tengo map; the
+// framework auto-decodes JSON resources, so there is no need for explicit
+// `json.decode` calls on the consumer side.
+create := func(value) {
+	return smart.createValueResource(constants.RTYPE_JSON, canonical.encode(value))
+}
+
+export ll.toStrict({
+	create: create
+})

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -4,11 +4,11 @@ ll := import("@platforma-sdk/workflow-tengo:ll")
 exec := import("@platforma-sdk/workflow-tengo:exec")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 pcolumn := import("@platforma-sdk/workflow-tengo:pframes.pcolumn")
-times := import("times")
 text := import("text")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
 xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 slices := import("@platforma-sdk/workflow-tengo:slices")
+maps := import("@platforma-sdk/workflow-tengo:maps")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 pt := import("@platforma-sdk/workflow-tengo:pt")
 qcReportColumns := import(":qc-report-columns")
@@ -95,7 +95,11 @@ self.body(func(inputs) {
 	translateNtToAaExpr := func(ntExpr, codonMap) {
 		seq := ntExpr.fillNull("").strToUpper()
 		seq = seq.strReplace("(.{3})", "$1|", { replaceAll: true })
-		for codon, aa in codonMap {
+		// Sorted-key iteration so the PTabler workflow JSON is byte-identical across
+		// runs (Tengo map iteration is non-deterministic). Codon replacements are
+		// pairwise-independent so the semantic result is unchanged.
+		for codon in maps.getKeys(codonMap) {
+			aa := codonMap[codon]
 			seq = seq.strReplace(codon + "|", aa + "|", { replaceAll: true, literal: true })
 		}
 		seq = seq.strReplace("\\|$", "", { replaceAll: false })

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -6,11 +6,12 @@ render := import("@platforma-sdk/workflow-tengo:render")
 maps := import("@platforma-sdk/workflow-tengo:maps")
 ll := import("@platforma-sdk/workflow-tengo:ll")
 assets := import("@platforma-sdk/workflow-tengo:assets")
-smart := import("@platforma-sdk/workflow-tengo:smart")
 file := import("@platforma-sdk/workflow-tengo:file")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
 exec := import("@platforma-sdk/workflow-tengo:exec")
-json := import("json")
+canonical := import("@platforma-sdk/workflow-tengo:canonical")
+
+canonicalResource := import(":canonical-resource")
 
 processTpl := assets.importTemplate(":process")
 repseqioLibraryTpl := assets.importTemplate(":repseqio-library")
@@ -110,7 +111,7 @@ wf.body(func(args) {
 			sequenceFragments: fragments,
 			checksumVersion: 1
 		}]
-		referenceLibrary = string(json.encode(library))
+		referenceLibrary = canonical.encode(library)
 	} else if mode == "libraryFile" {
 		fImport := file.importFile(args.libraryFile)
     	libraryImportHandle = fImport.handle
@@ -133,7 +134,7 @@ wf.body(func(args) {
 		referenceLibrary: referenceLibrary,
 		limitInput: limitInput,
 
-		params: smart.createJsonResource(maps.clone({
+		params: canonicalResource.create(maps.clone({
 			blockId: blockId,
 			perProcessMemGB: perProcessMemGB,
 			perProcessCPUs: perProcessCPUs,

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -9,7 +9,6 @@ ll := import("@platforma-sdk/workflow-tengo:ll")
 exec := import("@platforma-sdk/workflow-tengo:exec")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 pcolumn := import("@platforma-sdk/workflow-tengo:pframes.pcolumn")
-times := import("times")
 maps := import("@platforma-sdk/workflow-tengo:maps")
 text := import("text")
 
@@ -91,10 +90,11 @@ self.body(func(inputs) {
         arg("--species").arg("custom").
 		arg("--library").arg(libraryFileName)
 
-	if is_string(params.referenceLibrary) {
-		mixcrCmdBuilder.writeFile(libraryFileName, params.referenceLibrary).saveFile(libraryFileName)
+	referenceLibrary := inputs.referenceLibrary
+	if is_string(referenceLibrary) {
+		mixcrCmdBuilder.writeFile(libraryFileName, referenceLibrary).saveFile(libraryFileName)
 	} else {
-		mixcrCmdBuilder.addFile(libraryFileName, params.referenceLibrary)
+		mixcrCmdBuilder.addFile(libraryFileName, referenceLibrary)
 	}
 
     mixcrCmdBuilder.

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -3,6 +3,7 @@ self := import("@platforma-sdk/workflow-tengo:tpl.light")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 smart := import("@platforma-sdk/workflow-tengo:smart")
 slices := import("@platforma-sdk/workflow-tengo:slices")
+maps := import("@platforma-sdk/workflow-tengo:maps")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 exec := import("@platforma-sdk/workflow-tengo:exec")
 pt := import("@platforma-sdk/workflow-tengo:pt")
@@ -99,7 +100,11 @@ applyStopCodonReplacementsPt := func(df, opts) {
 	translateNtToAaExpr := func(ntExpr, codonMap) {
 		seq := ntExpr.fillNull("").strToUpper()
 		seq = seq.strReplace("(.{3})", "$1|", { replaceAll: true })
-		for codon, aa in codonMap {
+		// Sorted-key iteration so the PTabler workflow JSON is byte-identical across
+		// runs (Tengo map iteration is non-deterministic). Codon replacements are
+		// pairwise-independent so the semantic result is unchanged.
+		for codon in maps.getKeys(codonMap) {
+			aa := codonMap[codon]
 			seq = seq.strReplace(codon + "|", aa + "|", { replaceAll: true, literal: true })
 		}
 		seq = seq.strReplace("\\|$", "", { replaceAll: false })
@@ -165,6 +170,9 @@ self.body(func(inputs) {
 	clnsFile := inputs[pConstants.VALUE_FIELD_NAME]
 
 	params := inputs.params
+	// referenceLibrary lives on its own input field because it may be a
+	// resource reference that cannot round-trip through a JSON value resource.
+	referenceLibrary := inputs.referenceLibrary
 	exportArgs := params.exportArgs
 
 	clonotypeKeyColumns := params.clonotypeKeyColumns
@@ -227,10 +235,10 @@ self.body(func(inputs) {
 			arg("clones.tsv").
 			saveFile("clones.tsv")
 
-		if is_string(params.referenceLibrary) {
-			mixcrCmdBuilder.writeFile(libraryFileName, params.referenceLibrary).saveFile(libraryFileName)
+		if is_string(referenceLibrary) {
+			mixcrCmdBuilder.writeFile(libraryFileName, referenceLibrary).saveFile(libraryFileName)
 		} else {
-			mixcrCmdBuilder.addFile(libraryFileName, params.referenceLibrary)
+			mixcrCmdBuilder.addFile(libraryFileName, referenceLibrary)
 		}
 
 		return mixcrCmdBuilder.

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -18,6 +18,7 @@ mixcrExportTpl := assets.importTemplate(":mixcr-export")
 aggregateByClonotypeKeyTpl := assets.importTemplate(":aggregate-by-clonotype-key")
 exportReportTpl := assets.importTemplate(":export-report")
 calculateExportSpecs := import(":calculate-export-specs")
+canonicalResource := import(":canonical-resource")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -212,9 +213,12 @@ self.body(func(inputs) {
 			traceSteps: [{type: "milaboratories.mixcr-amplicon-alignment", id: blockId, importance: 20, label: "MiXCR generic amplicon"}],
 
 			extra: {
-				params: maps.clone({
+				// referenceLibrary is split out of the params map because it may be a
+				// resource reference (file or future-output) that cannot live inside a
+				// canonical-JSON value resource. The body template reads it from its own
+				// input field instead of params.referenceLibrary.
+				params: canonicalResource.create(maps.clone({
 					fileExtension: fileExtension,
-					referenceLibrary: referenceLibrary,
 					cloneClusteringMode: cloneClusteringMode,
 					hasUMI: hasUMI,
 					tagPattern: tagPattern,
@@ -223,7 +227,8 @@ self.body(func(inputs) {
 					badQualityThreshold: params.badQualityThreshold,
 					disableLowQualityMapping: params.disableLowQualityMapping,
 					isLibraryFileGzipped: params.isLibraryFileGzipped
-				}, { removeUndefs: true }),
+				}, { removeUndefs: true })),
+				referenceLibrary: referenceLibrary,
 				limitInput: limitInput
 			},
 
@@ -275,10 +280,11 @@ self.body(func(inputs) {
 		exportOutputs,
 		{
 			extra: {
-				params: maps.clone({
+				// referenceLibrary is split out of the params map: see comment on the
+				// mixcr-analyze call above.
+				params: canonicalResource.create(maps.clone({
 					clonotypeKeyColumns: clonotypeKeyColumns,
 					exportArgs: exportArgs,
-					referenceLibrary: referenceLibrary,
 					mixcrChains: mixcrChains,
 					mainIsProductiveColumn: mainIsProductiveColumn,
 					aminoAcidSeqColumns: aminoAcidSeqColumns,
@@ -287,7 +293,8 @@ self.body(func(inputs) {
 					stopCodonTypes: params.stopCodonTypes,
 					stopCodonReplacements: params.stopCodonReplacements,
 					isLibraryFileGzipped: params.isLibraryFileGzipped
-				}, { removeUndefs: true })
+				}, { removeUndefs: true })),
+				referenceLibrary: referenceLibrary
 			},
 			metaExtra: {
 				perProcessMemGB: perProcessMemGB
@@ -335,13 +342,13 @@ self.body(func(inputs) {
 			traceSteps: [{type: "milaboratories.mixcr-amplicon-alignment.aggregate", id: blockId + "." + chains, importance: 150, label: "Aggregate " + chains}],
 
 			extra: {
-				params: {
+				params: canonicalResource.create({
 					mainAbundanceColumnNormalized: mainAbundanceColumnNormalized,
 					mainAbundanceColumnUnnormalized: mainAbundanceColumnUnnormalized,
 					schemaPerClonotypeNoAggregates: columnsToSchema(columnsSpecPerClonotypeNoAggregates),
 					schemaPerClonotypeAggregates: columnsToSchema(columnsSpecPerClonotypeAggregates),
 					schemaPerSample: columnsToSchema(columnsSpecPerSample)
-				}
+				})
 			},
 			metaExtra: {
 				perProcessMemGB: perProcessMemGB
@@ -354,9 +361,14 @@ self.body(func(inputs) {
 	exportResults.addXsvOutputToBuilder(clones, "byCloneKeyBySample", "clonotypeProperties/bySample/" + chains + "/")
 	aggregationResults.addXsvOutputToBuilder(clones, "aggregates", "clonotypeProperties/aggregates/" + chains + "/")
 
+	// sampleIdAxisSpec and stopCodonReplacements are Tengo maps with no nested
+	// resource references; passed raw they would route to non-canonical
+	// createJsonResource() inside the SDK and produce unstable CIDs. Wrap each
+	// in a canonical JSON resource so the exportReportTpl render's identity is
+	// deterministic.
 	qcReportTable := render.create(exportReportTpl, {
 		clnsData: mixcrResults.outputData("clns"),
-		sampleIdAxisSpec: sampleIdAxisSpec,
+		sampleIdAxisSpec: canonicalResource.create(sampleIdAxisSpec),
 		chains: [chains],
 		library: referenceLibrary,
 		isLibraryFileGzipped: params.isLibraryFileGzipped,
@@ -366,7 +378,7 @@ self.body(func(inputs) {
 		perProcessMemGB: perProcessMemGB,
 		productiveFeature: productiveFeature,
 		stopCodonTypes: params.stopCodonTypes,
-		stopCodonReplacements: params.stopCodonReplacements
+		stopCodonReplacements: !is_undefined(params.stopCodonReplacements) ? canonicalResource.create(params.stopCodonReplacements) : undefined
 	})
 
 	return {


### PR DESCRIPTION
## What this does

Eliminates non-deterministic CID inputs in the published workflow so cross-project deduplication of the expensive MiXCR analyze / export / aggregate steps actually fires. Adds `workflow/src/canonical-resource.lib.tengo` and routes the `extra.params` maps passed to `pframes.processColumn` (and the `buildLibrary` reference encoding) through `canonical.encode` (key-sorted) instead of `json.encode`, whose Go-map iteration order varies per render. Also sorts codon-map iteration, moves `referenceLibrary` into its own input field, and bumps `block-tools`.

## Why

`json.encode` of a Tengo map produces non-deterministic bytes (random key order), so the per-element body-render templates get a different CID each run → `CIDConflictError` and silent cross-project dedup misses. Canonical (sorted-key) encoding makes those CIDs stable.

## Scope and dependencies

- Clears the **body-render-layer** (`RenderTemplate:1`) conflicts.
- **Pairs with SDK PR https://github.com/milaboratory/platforma/pull/1662**, which canonicalizes `createJsonResource` and the trace string in `workflow-tengo` — needed to fix the SDK-internal `json/getField:1` conflicts this block can't reach. Both land together.
- A **residual `json/getField:1`** conflict in the clns/export path survives both fixes and is under separate investigation (likely a tool- or data-blob-level determinism source).

## Testing

On a clean backend the body-render conflicts are gone and a first run of `wf.test.ts` passes. Full block CID-cleanliness depends on the paired SDK PR plus the residual-trap investigation.