### PR TITLE
Support disjoint assembling features for mid-region germline imputation (FR3 gap)

### DIFF
--- a/.changeset/disjoint-assembling-feature-fr3-imputation.md
+++ b/.changeset/disjoint-assembling-feature-fr3-imputation.md
@@ -1,0 +1,11 @@
+---
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': minor
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.ui': minor
+'@platforma-open/milaboratories.mixcr-amplicon-alignment': minor
+---
+
+Support disjoint assembling features for germline imputation across a mid-region (FR3) gap.
+
+When 2×150 reads don't overlap for long-CDR3 clones, a short uncovered window is left in FR3 and those clones are dropped at assembly. The assembling feature can now be a disjoint, comma-separated list of pieces (e.g. `FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End`) that brackets the gap: each mate fully covers one piece so the clone survives, fully-covered regions are exported as-is, and the skipped FR3 window plus the full VDJRegion are germline-imputed from the assigned V/J germline on export.
+
+The "Assembling feature" dropdown gains a "Custom (advanced)" option that reveals a free-text field for entering an arbitrary MiXCR gene feature, including such a disjoint one.

--- a/.changeset/disjoint-assembling-feature-fr3-imputation.md
+++ b/.changeset/disjoint-assembling-feature-fr3-imputation.md
@@ -1,6 +1,7 @@
 ---
 '@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow': minor
 '@platforma-open/milaboratories.mixcr-amplicon-alignment.ui': minor
+'@platforma-open/milaboratories.mixcr-amplicon-alignment.model': minor
 '@platforma-open/milaboratories.mixcr-amplicon-alignment': minor
 ---
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -260,6 +260,11 @@ export const platforma = BlockModel.create("Heavy")
   })
 
   .argsValid((ctx) => {
+    // A "Custom (advanced)" assembling feature left empty would reach parseAssemblingFeature and
+    // panic; block the run until it is filled.
+    if (ctx.args.assemblingFeature !== undefined && ctx.args.assemblingFeature.trim() === "") {
+      return false;
+    }
     const mode = ctx.uiState.referenceInputMode ?? "fastaSequence";
     const hasDataset = ctx.args.datasetRef !== undefined;
     if (mode === "libraryFile") {

--- a/test/src/exportSpecs.test.ts
+++ b/test/src/exportSpecs.test.ts
@@ -11,46 +11,13 @@ import { test, expect, describe } from "vitest";
  * - Other ranges: {XBegin:YEnd} format (e.g. {CDR1Begin:CDR3End})
  */
 
-// Mirrors the reference-point canonicalization MiXCR's GeneFeature.encode applies (range start ->
-// "Begin" form, range end -> "End" form), so predicted composite column names match MiXCR's output.
-const RANGE_START_CANONICAL: Record<string, string> = {
-  FR1End: "CDR1Begin",
-  CDR1End: "FR2Begin",
-  FR2End: "CDR2Begin",
-  CDR2End: "FR3Begin",
-  FR3End: "CDR3Begin",
-  CDR3End: "FR4Begin",
-};
-const RANGE_END_CANONICAL: Record<string, string> = {
-  CDR1Begin: "FR1End",
-  FR2Begin: "CDR1End",
-  CDR2Begin: "FR2End",
-  FR3Begin: "CDR2End",
-  CDR3Begin: "FR3End",
-  FR4Begin: "CDR3End",
-};
-function canonicalizeRefPoint(rp: string, isEnd: boolean): string {
-  const [base, offsetPart] = rp.split("(");
-  const suffix = offsetPart !== undefined ? `(${offsetPart}` : "";
-  const m = isEnd ? RANGE_END_CANONICAL : RANGE_START_CANONICAL;
-  return (m[base] ?? base) + suffix;
-}
-
 // Mirrors formatAssemblingFeature in calculate-export-specs.lib.tengo
 function formatAssemblingFeature(fstr: string): string {
   if (fstr === "VDJRegion" || fstr === "CDR3") return fstr;
-  // Disjoint feature: comma-separated pieces -> a single composite gene feature joined with "+",
-  // with reference points canonicalized to match MiXCR's column naming, e.g.
-  // "CDR1Begin:FR3Begin,CDR3Begin:FR4End" -> "{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}".
-  if (fstr.includes(",")) {
-    return fstr
-      .split(",")
-      .map((p) => {
-        const [b, e] = p.split(":");
-        return `{${canonicalizeRefPoint(b, false)}:${canonicalizeRefPoint(e, true)}}`;
-      })
-      .join("+");
-  }
+  // Disjoint feature (comma-separated): the composite is NOT exported as a single column (MiXCR
+  // renames such headers unpredictably); productiveFeature is overridden to CDR3, so this value is
+  // unused for disjoint.
+  if (fstr.includes(",")) return fstr;
   const parts = fstr.split(":");
   if (parts.length === 1) return `{${parts[0]}Begin:${parts[0]}End}`;
   return `{${parts[0]}Begin:${parts[1]}End}`;
@@ -60,6 +27,8 @@ function formatAssemblingFeature(fstr: string): string {
 // MiXCR export args (-isProductive/-isOOF/-hasStops/-nFeature). FR1:FR4 is the full
 // VDJRegion, so it is normalized to "VDJRegion" to match MiXCR's column naming.
 function productiveFeature(assemblingFeature: string): string {
+  // Disjoint feature: productivity is driven off CDR3 (predictable, covered), not the composite.
+  if (assemblingFeature.includes(",")) return "CDR3";
   if (assemblingFeature === "FR1:FR4") return "VDJRegion";
   return formatAssemblingFeature(assemblingFeature);
 }
@@ -67,6 +36,7 @@ function productiveFeature(assemblingFeature: string): string {
 // Mirrors outputProductiveFeature logic
 // MiXCR has named aliases for ranges ending at FR4; other ranges use {XBegin:YEnd}
 function outputProductiveFeature(assemblingFeature: string): string {
+  if (assemblingFeature.includes(",")) return "CDR3";
   const productive = formatAssemblingFeature(assemblingFeature);
   if (assemblingFeature !== "VDJRegion" && assemblingFeature !== "CDR3") {
     const parts = assemblingFeature.split(":");
@@ -204,6 +174,13 @@ function computeClonotypeKeyAndExport(
 
   if (assemblingFeature === "CDR3") {
     clonotypeKeyColumns = ["nSeqCDR3", "bestVGene", "bestJGene"];
+  } else if (assemblingFeature.includes(",")) {
+    // Disjoint feature: key on the covered whole regions (predictable names) + V + J.
+    clonotypeKeyColumns = [
+      ...parsed.nonImputed.filter((f) => f !== "VDJRegion").map((f) => `nSeq${f}`),
+      "bestVGene",
+      "bestJGene",
+    ];
   } else {
     // VDJRegion is the assembling feature itself only when it's NOT in the imputed list
     const vdjIsAssemblingFeature = imputedFeaturesMap["VDJRegion"] === undefined;
@@ -220,7 +197,9 @@ function computeClonotypeKeyAndExport(
 
   const isRangeFeature = assemblingFeature !== "CDR3" && assemblingFeature !== "VDJRegion";
   const vdjIsImputed = imputedFeaturesMap["VDJRegion"] === true;
-  const needsAssemblingFeatureExport = isRangeFeature && vdjIsImputed;
+  // Disjoint features never export a combined column (composite has no predictable name).
+  const needsAssemblingFeatureExport =
+    isRangeFeature && vdjIsImputed && !assemblingFeature.includes(",");
 
   let assemblingFeatureColumn: string | undefined;
   if (needsAssemblingFeatureExport) {
@@ -434,13 +413,10 @@ describe("export-report flag column naming (productiveFeature)", () => {
 // germline on export. The two pieces reach into FR3 via offsets, so FR3 is only partially
 // covered and must be germline-imputed (never exported as a real, non-imputed column).
 describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
-  // Valerio's real feature (excludes all of FR3). MiXCR's exported column for it was
-  // {CDR1Begin:CDR2End}+{CDR3Begin:FR4End} — FR3Begin canonicalized to CDR2End as a range end.
+  // Valerio's real feature (excludes all of FR3). The composite covered sequence is NOT exported
+  // as a single column (MiXCR renames such headers unpredictably); instead the block keys on the
+  // covered regions and drives productivity off CDR3 — all predictable, verbatim column names.
   const DISJOINT = "CDR1Begin:FR3Begin,CDR3Begin:FR4End";
-
-  test("formatAssemblingFeature emits a canonicalized +-concatenated composite gene feature", () => {
-    expect(formatAssemblingFeature(DISJOINT)).toBe("{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}");
-  });
 
   test("covered regions are non-imputed; FR3 gap, flanks and VDJRegion are imputed", () => {
     const r = parseAssemblingFeature(DISJOINT);
@@ -453,20 +429,23 @@ describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
     expect(r.nonImputed).not.toContain("FR3");
   });
 
-  test("clonotype key is the composite assembling-feature sequence, canonically named", () => {
-    // The composite (covered) sequence uniquely defines the clone; its predicted column name must
-    // match the canonical name MiXCR exports, else the downstream key hash can't find the column.
+  test("clonotype key is the covered whole regions plus V and J (predictable names)", () => {
     const r = computeClonotypeKeyAndExport(DISJOINT, true);
-    expect(r.clonotypeKeyColumns[0]).toBe("nSeq{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}");
-    expect(r.clonotypeKeyColumns).toContain("bestVGene");
-    expect(r.clonotypeKeyColumns).toContain("bestJGene");
-    expect(r.needsAssemblingFeatureExport).toBe(true);
+    expect(r.clonotypeKeyColumns).toEqual([
+      "nSeqCDR1",
+      "nSeqFR2",
+      "nSeqCDR2",
+      "nSeqCDR3",
+      "nSeqFR4",
+      "bestVGene",
+      "bestJGene",
+    ]);
+    // No composite assembling-feature column is exported for disjoint features.
+    expect(r.needsAssemblingFeatureExport).toBe(false);
   });
 
-  test("isProductive is computed over the (canonically named) composite feature", () => {
-    expect(`isProductive${outputProductiveFeature(DISJOINT)}`).toBe(
-      "isProductive{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}",
-    );
+  test("productivity is driven off CDR3 (predictable column name)", () => {
+    expect(`isProductive${outputProductiveFeature(DISJOINT)}`).toBe("isProductiveCDR3");
   });
 
   test("a wider gap leaves the same whole regions covered", () => {

--- a/test/src/exportSpecs.test.ts
+++ b/test/src/exportSpecs.test.ts
@@ -14,16 +14,17 @@ import { test, expect, describe } from "vitest";
 // Mirrors formatAssemblingFeature in calculate-export-specs.lib.tengo
 function formatAssemblingFeature(fstr: string): string {
   if (fstr === "VDJRegion" || fstr === "CDR3") return fstr;
-  // Disjoint feature: comma-separated pieces with explicit reference points, e.g.
-  // "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
+  // Disjoint feature: comma-separated pieces -> a single composite gene feature joined with "+",
+  // e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}"
+  // (--assemble-clonotypes-by uses the list form "[{..},{..}]"; export -nFeature uses this "+" form.)
   if (fstr.includes(",")) {
-    return `[${fstr
+    return fstr
       .split(",")
       .map((p) => {
         const [b, e] = p.split(":");
         return `{${b}:${e}}`;
       })
-      .join(",")}]`;
+      .join("+");
   }
   const parts = fstr.split(":");
   if (parts.length === 1) return `{${parts[0]}Begin:${parts[0]}End}`;
@@ -410,9 +411,9 @@ describe("export-report flag column naming (productiveFeature)", () => {
 describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
   const DISJOINT = "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End";
 
-  test("formatAssemblingFeature emits a MiXCR disjoint gene feature", () => {
+  test("formatAssemblingFeature emits a +-concatenated composite gene feature", () => {
     expect(formatAssemblingFeature(DISJOINT)).toBe(
-      "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]",
+      "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}",
     );
   });
 
@@ -429,7 +430,7 @@ describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
   test("clonotype key is the disjoint assembling-feature sequence (not imputed VDJRegion)", () => {
     // Imputed VDJRegion is not unique per clone; the disjoint assembling-feature sequence is.
     const r = computeClonotypeKeyAndExport(DISJOINT, true);
-    expect(r.clonotypeKeyColumns[0]).toBe("nSeq[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]");
+    expect(r.clonotypeKeyColumns[0]).toBe("nSeq{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}");
     expect(r.clonotypeKeyColumns).toContain("bestVGene");
     expect(r.clonotypeKeyColumns).toContain("bestJGene");
     expect(r.needsAssemblingFeatureExport).toBe(true);
@@ -437,7 +438,7 @@ describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
 
   test("isProductive is computed over the disjoint assembling feature", () => {
     expect(`isProductive${outputProductiveFeature(DISJOINT)}`).toBe(
-      "isProductive[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]",
+      "isProductive{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}",
     );
   });
 

--- a/test/src/exportSpecs.test.ts
+++ b/test/src/exportSpecs.test.ts
@@ -11,18 +11,43 @@ import { test, expect, describe } from "vitest";
  * - Other ranges: {XBegin:YEnd} format (e.g. {CDR1Begin:CDR3End})
  */
 
+// Mirrors the reference-point canonicalization MiXCR's GeneFeature.encode applies (range start ->
+// "Begin" form, range end -> "End" form), so predicted composite column names match MiXCR's output.
+const RANGE_START_CANONICAL: Record<string, string> = {
+  FR1End: "CDR1Begin",
+  CDR1End: "FR2Begin",
+  FR2End: "CDR2Begin",
+  CDR2End: "FR3Begin",
+  FR3End: "CDR3Begin",
+  CDR3End: "FR4Begin",
+};
+const RANGE_END_CANONICAL: Record<string, string> = {
+  CDR1Begin: "FR1End",
+  FR2Begin: "CDR1End",
+  CDR2Begin: "FR2End",
+  FR3Begin: "CDR2End",
+  CDR3Begin: "FR3End",
+  FR4Begin: "CDR3End",
+};
+function canonicalizeRefPoint(rp: string, isEnd: boolean): string {
+  const [base, offsetPart] = rp.split("(");
+  const suffix = offsetPart !== undefined ? `(${offsetPart}` : "";
+  const m = isEnd ? RANGE_END_CANONICAL : RANGE_START_CANONICAL;
+  return (m[base] ?? base) + suffix;
+}
+
 // Mirrors formatAssemblingFeature in calculate-export-specs.lib.tengo
 function formatAssemblingFeature(fstr: string): string {
   if (fstr === "VDJRegion" || fstr === "CDR3") return fstr;
   // Disjoint feature: comma-separated pieces -> a single composite gene feature joined with "+",
-  // e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}"
-  // (--assemble-clonotypes-by uses the list form "[{..},{..}]"; export -nFeature uses this "+" form.)
+  // with reference points canonicalized to match MiXCR's column naming, e.g.
+  // "CDR1Begin:FR3Begin,CDR3Begin:FR4End" -> "{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}".
   if (fstr.includes(",")) {
     return fstr
       .split(",")
       .map((p) => {
         const [b, e] = p.split(":");
-        return `{${b}:${e}}`;
+        return `{${canonicalizeRefPoint(b, false)}:${canonicalizeRefPoint(e, true)}}`;
       })
       .join("+");
   }
@@ -409,36 +434,38 @@ describe("export-report flag column naming (productiveFeature)", () => {
 // germline on export. The two pieces reach into FR3 via offsets, so FR3 is only partially
 // covered and must be germline-imputed (never exported as a real, non-imputed column).
 describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
-  const DISJOINT = "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End";
+  // Valerio's real feature (excludes all of FR3). MiXCR's exported column for it was
+  // {CDR1Begin:CDR2End}+{CDR3Begin:FR4End} — FR3Begin canonicalized to CDR2End as a range end.
+  const DISJOINT = "CDR1Begin:FR3Begin,CDR3Begin:FR4End";
 
-  test("formatAssemblingFeature emits a +-concatenated composite gene feature", () => {
-    expect(formatAssemblingFeature(DISJOINT)).toBe(
-      "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}",
-    );
+  test("formatAssemblingFeature emits a canonicalized +-concatenated composite gene feature", () => {
+    expect(formatAssemblingFeature(DISJOINT)).toBe("{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}");
   });
 
-  test("fully-covered regions are non-imputed; FR3 gap + VDJRegion are imputed", () => {
+  test("covered regions are non-imputed; FR3 gap, flanks and VDJRegion are imputed", () => {
     const r = parseAssemblingFeature(DISJOINT);
-    expect(r.nonImputed).toEqual(["FR1", "CDR1", "FR2", "CDR2", "CDR3", "FR4"]);
+    expect(r.nonImputed).toEqual(["CDR1", "FR2", "CDR2", "CDR3", "FR4"]);
+    expect(r.imputed).toContain("FR1");
     expect(r.imputed).toContain("FR3");
     expect(r.imputed).toContain("VDJRegion");
-    // FR3 is only partially covered — it must NOT be exported as a real (non-imputed) column,
-    // otherwise the "region_not_covered" placeholder would shadow the germline-imputed one.
+    // FR3 is not covered — it must NOT be exported as a real (non-imputed) column, otherwise the
+    // "region_not_covered" placeholder would shadow the germline-imputed one.
     expect(r.nonImputed).not.toContain("FR3");
   });
 
-  test("clonotype key is the disjoint assembling-feature sequence (not imputed VDJRegion)", () => {
-    // Imputed VDJRegion is not unique per clone; the disjoint assembling-feature sequence is.
+  test("clonotype key is the composite assembling-feature sequence, canonically named", () => {
+    // The composite (covered) sequence uniquely defines the clone; its predicted column name must
+    // match the canonical name MiXCR exports, else the downstream key hash can't find the column.
     const r = computeClonotypeKeyAndExport(DISJOINT, true);
-    expect(r.clonotypeKeyColumns[0]).toBe("nSeq{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}");
+    expect(r.clonotypeKeyColumns[0]).toBe("nSeq{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}");
     expect(r.clonotypeKeyColumns).toContain("bestVGene");
     expect(r.clonotypeKeyColumns).toContain("bestJGene");
     expect(r.needsAssemblingFeatureExport).toBe(true);
   });
 
-  test("isProductive is computed over the disjoint assembling feature", () => {
+  test("isProductive is computed over the (canonically named) composite feature", () => {
     expect(`isProductive${outputProductiveFeature(DISJOINT)}`).toBe(
-      "isProductive{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}",
+      "isProductive{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}",
     );
   });
 

--- a/test/src/exportSpecs.test.ts
+++ b/test/src/exportSpecs.test.ts
@@ -14,6 +14,17 @@ import { test, expect, describe } from "vitest";
 // Mirrors formatAssemblingFeature in calculate-export-specs.lib.tengo
 function formatAssemblingFeature(fstr: string): string {
   if (fstr === "VDJRegion" || fstr === "CDR3") return fstr;
+  // Disjoint feature: comma-separated pieces with explicit reference points, e.g.
+  // "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
+  if (fstr.includes(",")) {
+    return `[${fstr
+      .split(",")
+      .map((p) => {
+        const [b, e] = p.split(":");
+        return `{${b}:${e}}`;
+      })
+      .join(",")}]`;
+  }
   const parts = fstr.split(":");
   if (parts.length === 1) return `{${parts[0]}Begin:${parts[0]}End}`;
   return `{${parts[0]}Begin:${parts[1]}End}`;
@@ -42,6 +53,59 @@ function outputProductiveFeature(assemblingFeature: string): string {
   return productive;
 }
 
+// Region features in 5'->3' order, used to classify a disjoint assembling feature.
+const FEATURE_ORDER = ["FR1", "CDR1", "FR2", "CDR2", "FR3", "CDR3", "FR4"];
+
+// Mirrors parseRefPoint: "FR3Begin", "FR3Begin(+40)", "FR4End", "FR3End(-20)" -> parts
+function parseRefPoint(rp: string): { region: string; edge: string; offset: number } {
+  const [base, offsetPart] = rp.split("(");
+  let offset = 0;
+  if (offsetPart !== undefined) {
+    const n = parseInt(offsetPart.replace(")", ""), 10);
+    if (!Number.isNaN(n)) offset = n;
+  }
+  let region = "";
+  let edge = "";
+  if (base.endsWith("Begin")) {
+    edge = "Begin";
+    region = base.slice(0, -5);
+  } else if (base.endsWith("End")) {
+    edge = "End";
+    region = base.slice(0, -3);
+  }
+  return { region, edge, offset };
+}
+
+// Mirrors coveredRegions: whole regions fully spanned by some piece of a disjoint feature.
+function coveredRegions(disjointStr: string): Set<string> {
+  const covered = new Set<string>();
+  for (const p of disjointStr.split(",")) {
+    const be = p.split(":");
+    if (be.length !== 2) continue;
+    const s = parseRefPoint(be[0]);
+    const e = parseRefPoint(be[1]);
+    const si = FEATURE_ORDER.indexOf(s.region);
+    const ei = FEATURE_ORDER.indexOf(e.region);
+    if (si === -1 || ei === -1) continue;
+    let first = si;
+    if (s.edge === "Begin") {
+      if (s.offset > 0) first = si + 1;
+    } else {
+      first = si + 1;
+    }
+    let last = ei;
+    if (e.edge === "End") {
+      if (e.offset < 0) last = ei - 1;
+    } else {
+      last = ei - 1;
+    }
+    for (let i = first; i <= last; i++) {
+      if (i >= 0 && i < FEATURE_ORDER.length) covered.add(FEATURE_ORDER[i]);
+    }
+  }
+  return covered;
+}
+
 // Mirrors parseAssemblingFeature
 function parseAssemblingFeature(assemblingFeature: string) {
   if (assemblingFeature === "VDJRegion" || assemblingFeature === "CDR3") {
@@ -57,6 +121,20 @@ function parseAssemblingFeature(assemblingFeature: string) {
           ? ["CDR3"]
           : ["CDR1", "FR1", "FR2", "CDR2", "FR3", "CDR3", "FR4", "VDJRegion"],
     };
+  }
+
+  // Disjoint feature (comma-separated pieces): fully-covered regions are exported as-is,
+  // the partially-covered gap region + flanks + VDJRegion are germline-imputed.
+  if (assemblingFeature.includes(",")) {
+    const covered = coveredRegions(assemblingFeature);
+    const imputed: string[] = [];
+    const nonImputed: string[] = [];
+    for (const f of FEATURE_ORDER) {
+      if (covered.has(f)) nonImputed.push(f);
+      else imputed.push(f);
+    }
+    imputed.push("VDJRegion");
+    return { imputed, nonImputed };
   }
 
   const features = ["FR1", "CDR1", "FR2", "CDR2", "FR3", "CDR3", "FR4"];
@@ -321,5 +399,63 @@ describe("export-report flag column naming (productiveFeature)", () => {
 
   test("CDR1:CDR3 keeps {XBegin:YEnd} form", () => {
     expect(productiveFeature("CDR1:CDR3")).toBe("{CDR1Begin:CDR3End}");
+  });
+});
+
+// Disjoint assembling feature — recovers long-CDR3 clones whose 2x150 reads leave a ~6 nt
+// FR3 gap (Valerio "germline-imputation-fr3-gap"). The feature brackets the uncovered window;
+// each mate fully covers one piece, the clone survives assembly, and the gap is imputed from
+// germline on export. The two pieces reach into FR3 via offsets, so FR3 is only partially
+// covered and must be germline-imputed (never exported as a real, non-imputed column).
+describe("disjoint assembling feature (FR3-gap germline imputation)", () => {
+  const DISJOINT = "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End";
+
+  test("formatAssemblingFeature emits a MiXCR disjoint gene feature", () => {
+    expect(formatAssemblingFeature(DISJOINT)).toBe(
+      "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]",
+    );
+  });
+
+  test("fully-covered regions are non-imputed; FR3 gap + VDJRegion are imputed", () => {
+    const r = parseAssemblingFeature(DISJOINT);
+    expect(r.nonImputed).toEqual(["FR1", "CDR1", "FR2", "CDR2", "CDR3", "FR4"]);
+    expect(r.imputed).toContain("FR3");
+    expect(r.imputed).toContain("VDJRegion");
+    // FR3 is only partially covered — it must NOT be exported as a real (non-imputed) column,
+    // otherwise the "region_not_covered" placeholder would shadow the germline-imputed one.
+    expect(r.nonImputed).not.toContain("FR3");
+  });
+
+  test("clonotype key is the disjoint assembling-feature sequence (not imputed VDJRegion)", () => {
+    // Imputed VDJRegion is not unique per clone; the disjoint assembling-feature sequence is.
+    const r = computeClonotypeKeyAndExport(DISJOINT, true);
+    expect(r.clonotypeKeyColumns[0]).toBe("nSeq[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]");
+    expect(r.clonotypeKeyColumns).toContain("bestVGene");
+    expect(r.clonotypeKeyColumns).toContain("bestJGene");
+    expect(r.needsAssemblingFeatureExport).toBe(true);
+  });
+
+  test("isProductive is computed over the disjoint assembling feature", () => {
+    expect(`isProductive${outputProductiveFeature(DISJOINT)}`).toBe(
+      "isProductive[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]",
+    );
+  });
+
+  test("a wider gap leaves the same whole regions covered", () => {
+    // Offsets only change the imputed FR3 window width; whole-region coverage is unchanged.
+    const r = parseAssemblingFeature("FR1Begin:FR3Begin(+30),FR3Begin(+60):FR4End");
+    expect(r.nonImputed).toEqual(["FR1", "CDR1", "FR2", "CDR2", "CDR3", "FR4"]);
+    expect(r.imputed).toContain("FR3");
+  });
+
+  test("a 3-piece disjoint feature (two internal gaps) is classified by coverage", () => {
+    // Gaps in both FR2 and FR3: FR2 and FR3 are partial -> imputed; the rest stays covered.
+    const r = parseAssemblingFeature(
+      "FR1Begin:FR2Begin(+10),FR2Begin(+16):FR3Begin(+40),FR3Begin(+46):FR4End",
+    );
+    expect(r.nonImputed).toEqual(["FR1", "CDR1", "CDR2", "CDR3", "FR4"]);
+    expect(r.imputed).toContain("FR2");
+    expect(r.imputed).toContain("FR3");
+    expect(r.imputed).toContain("VDJRegion");
   });
 });

--- a/test/src/wf.test.ts
+++ b/test/src/wf.test.ts
@@ -265,6 +265,112 @@ blockTest(
 );
 
 blockTest(
+  "disjoint FR3-gap feature with imputation",
+  { timeout: 300000 },
+  async ({ rawPrj: project, ml, helpers, expect }) => {
+    const sndBlockId = await project.addBlock("Samples & Data", samplesAndDataBlockSpec);
+    const alignBlockId = await project.addBlock("MiXCR Amplicon Alignment", myBlockSpec);
+
+    const sample1Id = uniquePlId();
+    const dataset1Id = uniquePlId();
+
+    const r1Handle = await helpers.getLocalFileHandle("./assets/s1_R1.fastq.gz");
+    const r2Handle = await helpers.getLocalFileHandle("./assets/s1_R2.fastq.gz");
+
+    await project.setBlockArgs(sndBlockId, {
+      metadata: [],
+      sampleIds: [sample1Id],
+      sampleLabelColumnLabel: "Sample Name",
+      sampleLabels: { [sample1Id]: "Sample 1" },
+      datasets: [
+        {
+          id: dataset1Id,
+          label: "Dataset 1",
+          content: {
+            type: "Fastq",
+            readIndices: ["R1", "R2"],
+            gzipped: true,
+            data: {
+              [sample1Id]: {
+                R1: r1Handle,
+                R2: r2Handle,
+              },
+            },
+          },
+        },
+      ],
+    } satisfies SamplesAndDataBlockArgs);
+    await project.runBlock(sndBlockId);
+
+    await helpers.awaitBlockDoneAndGetStableBlockState(sndBlockId, 8000);
+
+    // Wait for input options to propagate
+    const alignStableState1 = (await awaitStableState(
+      project.getBlockState(alignBlockId),
+      25000,
+    )) as InferBlockState<typeof platforma>;
+
+    const alignOutputs1 = wrapOutputs(alignStableState1.outputs);
+
+    // Configure the amplicon alignment block with a DISJOINT assembling feature: two pieces
+    // bracketing a mid-FR3 window. The window is excluded from the clonal sequence (so a
+    // long-CDR3 clone whose mates don't overlap there still assembles) and is germline-imputed
+    // on export. Run on s1 to verify the mechanism + MiXCR's disjoint column naming independently
+    // of a natural read gap (the disjoint feature excludes the window regardless of coverage).
+    const vGenesFasta = `>ref_heavy\n${referenceSequence}`;
+    const jGenesFasta = `>ref_heavy_j\n${referenceSequence.slice(-80)}`;
+
+    await project.setBlockArgs(alignBlockId, {
+      datasetRef: alignOutputs1.inputOptions[0].ref,
+      chains: "IGHeavy",
+      tagPattern: "",
+      vGenes: vGenesFasta,
+      jGenes: jGenesFasta,
+      assemblingFeature: "FR1Begin:FR3Begin(+30),FR3Begin(+36):FR4End",
+      imputeGermline: true,
+      cloneClusteringMode: "relaxed",
+    } satisfies BlockArgs);
+
+    await project.runBlock(alignBlockId);
+    const alignStableState3 = await helpers.awaitBlockDoneAndGetStableBlockState(
+      alignBlockId,
+      250000,
+    );
+    const outputs3 = wrapOutputs<BlockOutputs>(
+      alignStableState3.outputs as unknown as BlockOutputs,
+    );
+
+    // Reaching "done" with complete reports implicitly verifies that (a) the disjoint feature
+    // assembled clones across mates and (b) MiXCR's exported column names for the disjoint
+    // feature match what the workflow requests (a naming mismatch would error the export).
+    expect(outputs3.reports.isComplete).toEqual(true);
+
+    const reportEntries = outputs3.reports.data;
+    const alignJsonReportEntry = reportEntries.find(
+      (entry) => entry.key[1] === "align" && entry.key[2] === "json",
+    );
+    expect(alignJsonReportEntry).toBeDefined();
+
+    const alignReport = AlignReport.parse(
+      JSON.parse(
+        Buffer.from(
+          await ml.driverKit.blobDriver.getContent(
+            alignJsonReportEntry!.value!.handle as Parameters<
+              typeof ml.driverKit.blobDriver.getContent
+            >[0],
+          ),
+        ).toString("utf8"),
+      ),
+    );
+    expect(alignReport).toBeDefined();
+    expect(alignReport.totalReadsProcessed).greaterThan(0);
+
+    const qcEntry = outputs3.qc!.data[0];
+    expect(qcEntry).toBeDefined();
+  },
+);
+
+blockTest(
   "CDR1:CDR3 without imputation",
   { timeout: 300000 },
   async ({ rawPrj: project, ml, helpers, expect }) => {

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -482,6 +482,9 @@ ATCGATCGATCG..."
     label="Custom assembling feature"
     placeholder="e.g. FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
     clearable
+    :error-message="
+      (assemblingFeature ?? '').trim() === '' ? 'Enter a MiXCR gene feature' : undefined
+    "
   >
     <template #tooltip>
       A MiXCR gene feature: a single region (VDJRegion, CDR3), a range (e.g. CDR1:FR4), or a

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -241,12 +241,54 @@ const assemblingFeatureOptions = [
   { value: "FR2:CDR3", label: "FR2:CDR3" },
   { value: "CDR2:CDR3", label: "CDR2:CDR3" },
   { value: "FR3:CDR3", label: "FR3:CDR3" },
+  { value: "custom", label: "Custom (advanced)" },
 ];
+
+// Real MiXCR feature values (everything except the "custom" sentinel used to reveal free text).
+const presetAssemblingFeatures = assemblingFeatureOptions
+  .map((o) => o.value)
+  .filter((v) => v !== "custom");
 
 const assemblingFeature = computed<AssemblingFeature>({
   get: () => app.model.args.assemblingFeature as AssemblingFeature,
   set: (value: AssemblingFeature) => {
     app.model.args.assemblingFeature = value;
+  },
+});
+
+// "Custom (advanced)" mode: reveals a free-text field so an arbitrary MiXCR gene feature can be
+// entered — including a disjoint one (e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End") that
+// brackets an uncovered window. Tracked as its own ref so an empty custom field doesn't snap the
+// dropdown back to a preset; the watch turns it on when a project loads with a non-preset value.
+const isCustomAssemblingFeature = ref(false);
+watch(
+  () => app.model.args.assemblingFeature,
+  (v) => {
+    if (v !== undefined && v !== "" && !presetAssemblingFeatures.includes(v)) {
+      isCustomAssemblingFeature.value = true;
+    }
+  },
+  { immediate: true },
+);
+
+const assemblingFeatureSelection = computed<string>({
+  get: () => {
+    if (isCustomAssemblingFeature.value) return "custom";
+    const v = app.model.args.assemblingFeature;
+    if (v === undefined || v === "") return "VDJRegion";
+    return presetAssemblingFeatures.includes(v) ? v : "custom";
+  },
+  set: (value: string) => {
+    if (value === "custom") {
+      isCustomAssemblingFeature.value = true;
+      // Don't carry a preset value into the custom text field.
+      if (presetAssemblingFeatures.includes(app.model.args.assemblingFeature ?? "")) {
+        app.model.args.assemblingFeature = "";
+      }
+    } else {
+      isCustomAssemblingFeature.value = false;
+      app.model.args.assemblingFeature = value;
+    }
   },
 });
 
@@ -424,12 +466,32 @@ ATCGATCGATCG..."
   <PlDropdown v-model="chains" :options="chainOptions" label="Chain selection" :required="true" />
 
   <PlDropdown
-    v-model="assemblingFeature"
+    v-model="assemblingFeatureSelection"
     :options="assemblingFeatureOptions"
     label="Assembling feature"
   >
-    <template #tooltip> Select the region used to assemble clonotypes. </template>
+    <template #tooltip>
+      Select the region used to assemble clonotypes. Choose "Custom (advanced)" to enter an
+      arbitrary MiXCR gene feature, including a disjoint one that brackets an uncovered window.
+    </template>
   </PlDropdown>
+
+  <PlTextField
+    v-if="isCustomAssemblingFeature"
+    v-model="assemblingFeature"
+    label="Custom assembling feature"
+    placeholder="e.g. FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
+    clearable
+  >
+    <template #tooltip>
+      A MiXCR gene feature: a single region (VDJRegion, CDR3), a range (e.g. CDR1:FR4), or a
+      disjoint, comma-separated list of pieces with explicit reference points — e.g.
+      FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End — which brackets an uncovered mid-region window
+      so long-CDR3 clones whose paired reads don't overlap there still assemble (each mate covers
+      one piece). Enable "Impute non-covered parts from germline" to reconstruct the skipped window
+      and the full VDJRegion from the assigned V/J germline.
+    </template>
+  </PlTextField>
 
   <PlCheckbox v-model="imputeGermline"> Impute non-covered parts from germline </PlCheckbox>
 

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -486,10 +486,10 @@ ATCGATCGATCG..."
     <template #tooltip>
       A MiXCR gene feature: a single region (VDJRegion, CDR3), a range (e.g. CDR1:FR4), or a
       disjoint, comma-separated list of pieces with explicit reference points — e.g.
-      FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End — which brackets an uncovered mid-region window
-      so long-CDR3 clones whose paired reads don't overlap there still assemble (each mate covers
-      one piece). Enable "Impute non-covered parts from germline" to reconstruct the skipped window
-      and the full VDJRegion from the assigned V/J germline.
+      FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End — which brackets an uncovered mid-region window so
+      long-CDR3 clones whose paired reads don't overlap there still assemble (each mate covers one
+      piece). Enable "Impute non-covered parts from germline" to reconstruct the skipped window and
+      the full VDJRegion from the assigned V/J germline.
     </template>
   </PlTextField>
 

--- a/workflow/src/calculate-export-specs.lib.tengo
+++ b/workflow/src/calculate-export-specs.lib.tengo
@@ -152,6 +152,44 @@ coveredRegions := func(disjointStr) {
 	return covered
 }
 
+// MiXCR GeneFeature.encode names a range's START with a "Begin" reference point and its END with
+// an "End" one, canonicalizing boundary points to that form (e.g. a range ending at FR3Begin is
+// exported as CDR2End, since FR3Begin == CDR2End). We replicate that here so the column names we
+// predict for a disjoint (composite) feature match MiXCR's actual exported headers. NOTE: verified
+// for plain boundary points (no offsets); offset points like FR3Begin(+40) are passed through with
+// the base point canonicalized, which is the untested case.
+rangeStartCanonical := {
+	"FR1End": "CDR1Begin",
+	"CDR1End": "FR2Begin",
+	"FR2End": "CDR2Begin",
+	"CDR2End": "FR3Begin",
+	"FR3End": "CDR3Begin",
+	"CDR3End": "FR4Begin"
+}
+rangeEndCanonical := {
+	"CDR1Begin": "FR1End",
+	"FR2Begin": "CDR1End",
+	"CDR2Begin": "FR2End",
+	"FR3Begin": "CDR2End",
+	"CDR3Begin": "FR3End",
+	"FR4Begin": "CDR3End"
+}
+
+canonicalizeRefPoint := func(rp, isEnd) {
+	parts := text.split(rp, "(")
+	base := parts[0]
+	suffix := ""
+	if len(parts) >= 2 {
+		suffix = "(" + parts[1]
+	}
+	m := isEnd ? rangeEndCanonical : rangeStartCanonical
+	mapped := m[base]
+	if !is_undefined(mapped) {
+		base = mapped
+	}
+	return base + suffix
+}
+
 parseAssemblingFeature := func(assemblingFeature) {
 	if assemblingFeature == "VDJRegion" || assemblingFeature == "CDR3" {
 		return {
@@ -291,11 +329,12 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 			return fstr
 		}
 		// Disjoint feature: comma-separated pieces -> a single composite MiXCR gene feature joined
-		// with "+", e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
-		//   -> "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}".
-		// This is the form GeneFeature.parse accepts for exportClones -nFeature/-aaFeature/
-		// -isProductive (it splits on "+" respecting {} brackets). NOTE: --assemble-clonotypes-by
-		// takes the LIST form "[{..},{..}]" instead — see mixcr-analyze.tpl.tengo.
+		// with "+" (the form GeneFeature.parse accepts for exportClones -nFeature/-aaFeature/
+		// -isProductive; it splits on "+" respecting {} brackets). Reference points are canonicalized
+		// to match MiXCR's own column naming, e.g.
+		//   "CDR1Begin:FR3Begin,CDR3Begin:FR4End" -> "{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}".
+		// NOTE: --assemble-clonotypes-by takes the LIST form "[{..},{..}]" instead (see
+		// mixcr-analyze.tpl.tengo).
 		if text.contains(fstr, ",") {
 			res := ""
 			for i, p in text.split(fstr, ",") {
@@ -303,7 +342,7 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 				if i > 0 {
 					res += "+"
 				}
-				res += "{" + pbe[0] + ":" + pbe[1] + "}"
+				res += "{" + canonicalizeRefPoint(pbe[0], false) + ":" + canonicalizeRefPoint(pbe[1], true) + "}"
 			}
 			return res
 		}

--- a/workflow/src/calculate-export-specs.lib.tengo
+++ b/workflow/src/calculate-export-specs.lib.tengo
@@ -152,44 +152,6 @@ coveredRegions := func(disjointStr) {
 	return covered
 }
 
-// MiXCR GeneFeature.encode names a range's START with a "Begin" reference point and its END with
-// an "End" one, canonicalizing boundary points to that form (e.g. a range ending at FR3Begin is
-// exported as CDR2End, since FR3Begin == CDR2End). We replicate that here so the column names we
-// predict for a disjoint (composite) feature match MiXCR's actual exported headers. NOTE: verified
-// for plain boundary points (no offsets); offset points like FR3Begin(+40) are passed through with
-// the base point canonicalized, which is the untested case.
-rangeStartCanonical := {
-	"FR1End": "CDR1Begin",
-	"CDR1End": "FR2Begin",
-	"FR2End": "CDR2Begin",
-	"CDR2End": "FR3Begin",
-	"FR3End": "CDR3Begin",
-	"CDR3End": "FR4Begin"
-}
-rangeEndCanonical := {
-	"CDR1Begin": "FR1End",
-	"FR2Begin": "CDR1End",
-	"CDR2Begin": "FR2End",
-	"FR3Begin": "CDR2End",
-	"CDR3Begin": "FR3End",
-	"FR4Begin": "CDR3End"
-}
-
-canonicalizeRefPoint := func(rp, isEnd) {
-	parts := text.split(rp, "(")
-	base := parts[0]
-	suffix := ""
-	if len(parts) >= 2 {
-		suffix = "(" + parts[1]
-	}
-	m := isEnd ? rangeEndCanonical : rangeStartCanonical
-	mapped := m[base]
-	if !is_undefined(mapped) {
-		base = mapped
-	}
-	return base + suffix
-}
-
 parseAssemblingFeature := func(assemblingFeature) {
 	if assemblingFeature == "VDJRegion" || assemblingFeature == "CDR3" {
 		return {
@@ -328,23 +290,14 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr
 		}
-		// Disjoint feature: comma-separated pieces -> a single composite MiXCR gene feature joined
-		// with "+" (the form GeneFeature.parse accepts for exportClones -nFeature/-aaFeature/
-		// -isProductive; it splits on "+" respecting {} brackets). Reference points are canonicalized
-		// to match MiXCR's own column naming, e.g.
-		//   "CDR1Begin:FR3Begin,CDR3Begin:FR4End" -> "{CDR1Begin:CDR2End}+{CDR3Begin:FR4End}".
-		// NOTE: --assemble-clonotypes-by takes the LIST form "[{..},{..}]" instead (see
-		// mixcr-analyze.tpl.tengo).
+		// Disjoint feature (comma-separated pieces): the composite covered sequence is NOT exported
+		// as a single column — MiXCR's GeneFeature.encode rewrites such a column header
+		// unpredictably (ref-point duals like FR3Begin->CDR2End, and whole-region ranges collapse to
+		// their name, e.g. {CDR3Begin:CDR3End}->CDR3). Instead we key on the individual covered
+		// regions and drive productivity off CDR3 (see the disjoint override + key branch below), so
+		// this return value is unused for disjoint features (productiveFeature is overridden).
 		if text.contains(fstr, ",") {
-			res := ""
-			for i, p in text.split(fstr, ",") {
-				pbe := text.split(p, ":")
-				if i > 0 {
-					res += "+"
-				}
-				res += "{" + canonicalizeRefPoint(pbe[0], false) + ":" + canonicalizeRefPoint(pbe[1], true) + "}"
-			}
-			return res
+			return fstr
 		}
 		parts := text.split(fstr, ":")
 		if len(parts) == 1 {
@@ -393,6 +346,16 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 		anchorFeature = outputProductiveFeature
 	}
 
+	// Disjoint feature: MiXCR can't export the composite covered sequence as a predictably-named
+	// single column, so drive productivity off CDR3 (always covered, predictable name) and make the
+	// full-length imputed VDJRegion the main sequence; the clonotype key is the covered regions
+	// (see the key branch below).
+	if text.contains(assemblingFeature, ",") {
+		productiveFeature = "CDR3"
+		outputProductiveFeature = "CDR3"
+		anchorFeature = "VDJRegion"
+	}
+
 	features := parsedFeature.nonImputed
 	if imputeGermline {
 		features = features + parsedFeature.imputed
@@ -407,6 +370,20 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 			[ "-vGene" ],
 			[ "-jGene" ]
 		]
+	} else if text.contains(assemblingFeature, ",") {
+		// Disjoint feature: key on the covered whole regions (predictable, verbatim column names,
+		// already exported in the feature loop) plus V and J. The composite covered sequence can't
+		// be a single predictably-named column; the covered regions together identify the clone
+		// (for synthetic fixed-framework libraries CDR1/CDR2 are independently diversified, so all
+		// covered regions are needed to distinguish members — CDR3 alone would collapse them).
+		for f in parsedFeature.nonImputed {
+			if f != "VDJRegion" {
+				clonotypeKeyColumns = append(clonotypeKeyColumns, "nSeq" + f)
+				clonotypeKeyArgs = append(clonotypeKeyArgs, [ "-nFeature", f ])
+			}
+		}
+		clonotypeKeyColumns = append(clonotypeKeyColumns, "bestVGene", "bestJGene")
+		clonotypeKeyArgs = append(clonotypeKeyArgs, [ "-vGene" ], [ "-jGene" ])
 	} else {
 		// VDJRegion is the assembling feature itself only when it's NOT in the imputed list
 		// (e.g. VDJRegion or FR1:FR4 as the assembling feature)
@@ -448,7 +425,9 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 	// For range features where VDJRegion is not the assembling feature, we need to export
 	// the combined assembling feature sequence column explicitly (individual features are
 	// exported in the loop below, but the combined feature like {CDR1Begin:CDR3End} is not)
-	needsAssemblingFeatureExport := assemblingFeature != "CDR3" && assemblingFeature != "VDJRegion" && !is_undefined(imputedFeaturesMap["VDJRegion"])
+	// Disjoint features are excluded: their composite sequence has no predictably-named MiXCR
+	// column, so we key on covered regions instead and never export a combined column.
+	needsAssemblingFeatureExport := assemblingFeature != "CDR3" && assemblingFeature != "VDJRegion" && !text.contains(assemblingFeature, ",") && !is_undefined(imputedFeaturesMap["VDJRegion"])
 	if needsAssemblingFeatureExport {
 		featureIdL := text.to_lower(formatId(assemblingFeature))
 		keyColName := "nSeq" + outputProductiveFeature

--- a/workflow/src/calculate-export-specs.lib.tengo
+++ b/workflow/src/calculate-export-specs.lib.tengo
@@ -290,18 +290,22 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr
 		}
-		// Disjoint feature: comma-separated pieces with explicit reference points, e.g.
-		// "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
+		// Disjoint feature: comma-separated pieces -> a single composite MiXCR gene feature joined
+		// with "+", e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
+		//   -> "{FR1Begin:FR3Begin(+40)}+{FR3Begin(+46):FR4End}".
+		// This is the form GeneFeature.parse accepts for exportClones -nFeature/-aaFeature/
+		// -isProductive (it splits on "+" respecting {} brackets). NOTE: --assemble-clonotypes-by
+		// takes the LIST form "[{..},{..}]" instead — see mixcr-analyze.tpl.tengo.
 		if text.contains(fstr, ",") {
-			res := "["
+			res := ""
 			for i, p in text.split(fstr, ",") {
 				pbe := text.split(p, ":")
 				if i > 0 {
-					res += ","
+					res += "+"
 				}
 				res += "{" + pbe[0] + ":" + pbe[1] + "}"
 			}
-			return res + "]"
+			return res
 		}
 		parts := text.split(fstr, ":")
 		if len(parts) == 1 {

--- a/workflow/src/calculate-export-specs.lib.tengo
+++ b/workflow/src/calculate-export-specs.lib.tengo
@@ -40,9 +40,9 @@ toCombinedDomainValue := func(spec) {
 
 // sometimes we need to format assembling feature to be used in column ids
 formatId := func(input) {
-    noNums := text.re_replace(`\(\s*-?\d+(\s*,\s*-?\d+)*\s*\)`, input, "")
-    noBraces := text.re_replace(`[{}\(\)]`, noNums, "")
-    result   := text.re_replace(`:`, noBraces, "-")
+    noNums := text.re_replace(`\(\s*[-+]?\d+(\s*,\s*[-+]?\d+)*\s*\)`, input, "")
+    noBraces := text.re_replace(`[\[\](){}]`, noNums, "")
+    result   := text.re_replace(`[:,]`, noBraces, "-")
     return result
 }
 
@@ -50,6 +50,106 @@ addSpec := func(columns, additionalSpec) {
 	return slices.map(columns, func(columnSpec) {
 		return maps.deepMerge(columnSpec, additionalSpec)
 	})
+}
+
+// Region features in 5'->3' order, used to classify a disjoint assembling feature.
+featureOrder := ["FR1", "CDR1", "FR2", "CDR2", "FR3", "CDR3", "FR4"]
+
+featureIndex := func(r) {
+	for i, f in featureOrder {
+		if f == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// Parse a MiXCR reference point ("FR3Begin", "FR3Begin(+40)", "FR4End", "FR3End(-20)")
+// into { region, edge ("Begin"/"End"), offset }.
+parseRefPoint := func(rp) {
+	parts := text.split(rp, "(")
+	base := parts[0]
+	offset := 0
+	if len(parts) >= 2 {
+		inner := parts[1]
+		if text.has_suffix(inner, ")") {
+			inner = inner[0:len(inner) - 1]
+		}
+		neg := false
+		if len(inner) > 0 {
+			if inner[0] == '+' {
+				inner = inner[1:]
+			} else if inner[0] == '-' {
+				neg = true
+				inner = inner[1:]
+			}
+		}
+		o := int(inner)
+		if !is_undefined(o) {
+			offset = o
+		}
+		if neg {
+			offset = -offset
+		}
+	}
+	region := ""
+	edge := ""
+	if text.has_suffix(base, "Begin") {
+		edge = "Begin"
+		region = base[0:len(base) - 5]
+	} else if text.has_suffix(base, "End") {
+		edge = "End"
+		region = base[0:len(base) - 3]
+	}
+	return {
+		region: region,
+		edge: edge,
+		offset: offset
+	}
+}
+
+// Given a disjoint assembling feature (comma-separated "begin:end" pieces with explicit
+// reference points), return the set of whole region features fully covered by some piece.
+// A region is fully covered only when a piece spans it edge-to-edge; a region a piece only
+// reaches into via an offset (e.g. FR3 in "...:FR3Begin(+40)") is left uncovered so it gets
+// germline-imputed on export.
+coveredRegions := func(disjointStr) {
+	covered := {}
+	for p in text.split(disjointStr, ",") {
+		be := text.split(p, ":")
+		if len(be) != 2 {
+			continue
+		}
+		s := parseRefPoint(be[0])
+		e := parseRefPoint(be[1])
+		si := featureIndex(s.region)
+		ei := featureIndex(e.region)
+		if si == -1 || ei == -1 {
+			continue
+		}
+		first := si
+		if s.edge == "Begin" {
+			if s.offset > 0 {
+				first = si + 1
+			}
+		} else {
+			first = si + 1
+		}
+		last := ei
+		if e.edge == "End" {
+			if e.offset < 0 {
+				last = ei - 1
+			}
+		} else {
+			last = ei - 1
+		}
+		for i := first; i <= last; i++ {
+			if i >= 0 && i < len(featureOrder) {
+				covered[featureOrder[i]] = true
+			}
+		}
+	}
+	return covered
 }
 
 parseAssemblingFeature := func(assemblingFeature) {
@@ -63,6 +163,37 @@ parseAssemblingFeature := func(assemblingFeature) {
 			coreGeneFeatures: {
 				V: "{FR1Begin:FR3End}",
 				J: "FR4"
+			}
+		}
+	}
+
+	// Disjoint assembling feature: comma-separated pieces bracketing an uncovered mid-region
+	// window, e.g. "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" for the ~6 nt FR3 gap left by
+	// non-overlapping 2x150 reads on long-CDR3 clones. Each mate fully covers one piece, so the
+	// clone survives assembly; fully-covered whole regions are exported as-is (nonImputed), while
+	// the partially-covered gap region, any flanks, and the full VDJRegion are germline-imputed on
+	// export (MiXCR fills interior uncovered positions from the assigned V/J germline).
+	if text.contains(assemblingFeature, ",") {
+		covered := coveredRegions(assemblingFeature)
+		imputed := []
+		nonImputed := []
+		for f in featureOrder {
+			if !is_undefined(covered[f]) {
+				nonImputed = append(nonImputed, f)
+			} else {
+				imputed = append(imputed, f)
+			}
+		}
+		// The full VDJRegion always spans the gap, so it is never fully covered here.
+		imputed = append(imputed, "VDJRegion")
+		return {
+			imputed: imputed,
+			nonImputed: nonImputed,
+			// V/J mutation cores would span the imputed gap, so mutation columns are skipped for
+			// disjoint features (undefined core => the mutation loops no-op).
+			coreGeneFeatures: {
+				V: undefined,
+				J: undefined
 			}
 		}
 	}
@@ -158,6 +289,19 @@ calculateExportSpecs := func(presetSpecForBack, blockId) {
 	formatAssemblingFeature := func(fstr) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr
+		}
+		// Disjoint feature: comma-separated pieces with explicit reference points, e.g.
+		// "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End" -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
+		if text.contains(fstr, ",") {
+			res := "["
+			for i, p in text.split(fstr, ",") {
+				pbe := text.split(p, ":")
+				if i > 0 {
+					res += ","
+				}
+				res += "{" + pbe[0] + ":" + pbe[1] + "}"
+			}
+			return res + "]"
 		}
 		parts := text.split(fstr, ":")
 		if len(parts) == 1 {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -69,9 +69,27 @@ self.body(func(inputs) {
 		mixcrCmdBuilder.arg("generic-amplicon")
 	}
 
+	// Format the assembling feature into MiXCR --assemble-clonotypes-by syntax.
+	//   VDJRegion, CDR3      -> unchanged
+	//   "X" / "X:Y"          -> {XBegin:XEnd} / {XBegin:YEnd}
+	//   disjoint (has ",")   -> [{p1},{p2},...] with explicit reference points, e.g.
+	//     "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
+	//     -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
+	// Keep this in sync with formatAssemblingFeature in calculate-export-specs.lib.tengo.
 	formatAssemblingFeature := func(fstr) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr
+		}
+		if text.contains(fstr, ",") {
+			res := "["
+			for i, p in text.split(fstr, ",") {
+				pbe := text.split(p, ":")
+				if i > 0 {
+					res += ","
+				}
+				res += "{" + pbe[0] + ":" + pbe[1] + "}"
+			}
+			return res + "]"
 		}
 		parts := text.split(fstr, ":")
 		if len(parts) == 1 {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -76,9 +76,9 @@ self.body(func(inputs) {
 	//     "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
 	//     -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
 	// NOTE: --assemble-clonotypes-by takes this LIST form. The export side
-	// (calculate-export-specs.lib.tengo) instead "+"-concatenates the pieces
-	// ("{p1}+{p2}") because exportClones -nFeature parses a single composite
-	// GeneFeature, not the list form.
+	// (calculate-export-specs.lib.tengo) does NOT reference the composite feature at all — it keys
+	// the clonotype on the individual covered regions instead, because MiXCR renames a composite
+	// export column unpredictably.
 	formatAssemblingFeature := func(fstr) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -75,7 +75,10 @@ self.body(func(inputs) {
 	//   disjoint (has ",")   -> [{p1},{p2},...] with explicit reference points, e.g.
 	//     "FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End"
 	//     -> "[{FR1Begin:FR3Begin(+40)},{FR3Begin(+46):FR4End}]"
-	// Keep this in sync with formatAssemblingFeature in calculate-export-specs.lib.tengo.
+	// NOTE: --assemble-clonotypes-by takes this LIST form. The export side
+	// (calculate-export-specs.lib.tengo) instead "+"-concatenates the pieces
+	// ("{p1}+{p2}") because exportClones -nFeature parses a single composite
+	// GeneFeature, not the list form.
 	formatAssemblingFeature := func(fstr) {
 		if fstr == "VDJRegion" || fstr == "CDR3" {
 			return fstr


### PR DESCRIPTION
## What

Adds support for a **disjoint assembling feature** to the MiXCR Amplicon Alignment block, so clonotypes can be assembled across an uncovered mid-region window.

- **Workflow** — `assemblingFeature` may now be a disjoint, comma-separated list of pieces with explicit reference points, e.g. `FR1Begin:FR3Begin(+40),FR3Begin(+46):FR4End`. `formatAssemblingFeature` emits the MiXCR `--assemble-clonotypes-by [{…},{…}]` form; `parseAssemblingFeature` classifies fully-covered regions as exported-as-is and the partially-covered gap region, flanks, and full `VDJRegion` as germline-imputed.
- **UI** — the "Assembling feature" dropdown gains a **Custom (advanced)** option that reveals a free-text field for entering an arbitrary MiXCR gene feature (including a disjoint one). UI-only; the model already types `assemblingFeature` as a free string.

## Why

With 2×150 sequencing, long-CDR3 clones can have paired reads that don't overlap, leaving a short uncovered window in FR3. Default full-`VDJRegion` assembly drops those clones. A disjoint assembling feature that brackets the gap lets each mate fully cover one piece, so the clone survives; enabling "Impute non-covered parts from germline" reconstructs the skipped window (and the full VDJRegion) from the assigned V/J germline — the same way the parental/reference sequence fills the gap.

## Testing

- `exportSpecs` unit tests (grammar + region classification): **37/37**, incl. 6 new disjoint cases.
- Tengo compiles (`pl-tengo check`); UI type-check + lint + build green.
- Added a `wf.test` e2e case (`disjoint FR3-gap feature with imputation`) exercising a disjoint feature end-to-end on the `s1` fixture. Not yet run in a dev backend (native-module / registry-auth gap in the local env) — relying on CI to run it here.

## Notes

- The one behavior to confirm on a real MiXCR run: the exported column names for a disjoint feature (`nSeq[{…}]`, `isProductive[{…}]`). The code extends the existing braced-range pattern (`nSeq{CDR1Begin:CDR3End}`, already covered by tests); if MiXCR names them differently, the `wf.test` surfaces it and the `outputProductiveFeature`/key wiring is the adjustment point.
- Model untouched → no collision with the in-flight structurer migration.
- `@platforma-sdk/block-tools` in the workspace catalog is `2.12.0` (latest `2.12.9`) — pre-existing on `main`, not bumped here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable disjoint clonotype assembly across uncovered mid-region windows.
- Workflow formatting now converts comma-separated feature pieces into MiXCR disjoint-feature syntax and classifies fully covered versus germline-imputed regions.
- Export specifications now use the disjoint feature for clonotype keys and productivity while imputing the skipped regions and full VDJRegion.
- The settings UI adds a Custom (advanced) assembling-feature input.
- Unit and workflow tests cover formatting, region classification, column expectations, and an end-to-end FR3-gap configuration.
- Important touched terms:
  - Assembling feature — the gene feature MiXCR uses to define clonotype sequences; changed from preset contiguous features to also support custom disjoint features.
  - Disjoint assembling feature — multiple separated feature pieces assembled as one clonotype key; newly formatted as MiXCR `[{…},{…}]` syntax.
  - Reference point — a named feature boundary with an optional nucleotide offset, such as `FR3Begin(+40)`; newly parsed to determine whole-region coverage.
  - Germline imputation — reconstruction of uncovered sequence from assigned V/J germline genes; extended to the skipped gap, partially covered regions, flanks, and full VDJRegion.
  - Clonotype key — columns identifying a unique assembled clone; changed to use the exported disjoint-feature nucleotide sequence with best V and J genes.
  - VDJRegion — the full variable-diversity-joining region; classified as imputed whenever assembly uses a disjoint feature.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The empty custom assembling-feature path must be rejected or defaulted before merging because it currently causes the workflow to panic.

The new clearable custom field can persist an empty assemblingFeature, argument validation allows it through, and the export-spec parser then panics on the invalid shape.

ui/src/pages/SettingsPanel.vue, workflow/src/calculate-export-specs.lib.tengo
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/SettingsPanel.vue | Adds custom assembling-feature selection and input, but permits an empty value that reaches the workflow and fails. |
| workflow/src/calculate-export-specs.lib.tengo | Formats and classifies disjoint features, constructs export columns, and selects the disjoint sequence as the clonotype key. |
| workflow/src/mixcr-analyze.tpl.tengo | Converts comma-separated feature pieces into MiXCR disjoint-feature command syntax. |
| test/src/exportSpecs.test.ts | Adds focused tests for disjoint formatting, coverage classification, clonotype keys, and productivity-column expectations. |
| test/src/wf.test.ts | Adds an end-to-end workflow case using a disjoint FR3-gap feature with germline imputation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Custom assembling feature] --> F[Format comma-separated pieces]
  F --> A[MiXCR assemble-clonotypes-by]
  F --> C[Classify covered regions]
  C --> N[Export covered regions as-is]
  C --> I[Impute gaps and VDJRegion]
  A --> K[Disjoint sequence clonotype key]
  N --> O[Clonotype outputs]
  I --> O
  K --> O
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aui%2Fsrc%2Fpages%2FSettingsPanel.vue%3A475-481%0A**Empty%20custom%20feature%20crashes%20workflow**%0A%0AWhen%20a%20user%20selects%20Custom%20%28advanced%29%20and%20leaves%20or%20clears%20this%20field%2C%20the%20empty%20string%20passes%20argument%20validation%20and%20reaches%20%60parseAssemblingFeature%60%2C%20which%20panics%20because%20the%20value%20has%20no%20valid%20endpoints%2C%20causing%20the%20analysis%20run%20to%20fail.%0A%0A&repo=platforma-open%2Fmixcr-amplicon-alignment&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ui/src/pages/SettingsPanel.vue:475-481
**Empty custom feature crashes workflow**

When a user selects Custom (advanced) and leaves or clears this field, the empty string passes argument validation and reaches `parseAssemblingFeature`, which panics because the value has no valid endpoints, causing the analysis run to fail.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add a &quot;Custom (advanced)&quot; assembling-fea..."](https://github.com/platforma-open/mixcr-amplicon-alignment/commit/ca117b87ebd46e57586f1a0d7eba69c0626d2367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47001092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->