### PR TITLE
MILAB-6721: stop double-counting input size in the analyze memory formula

### DIFF
--- a/.changeset/analyze-memory-no-double-count.md
+++ b/.changeset/analyze-memory-no-double-count.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow": patch
+---
+
+Analyze memory request no longer double-counts input size on top of the memory floor. The formula added a `4 x size("reads")` data term on top of the 64 GiB floor, but that floor is already a total-memory value, so the input was counted twice: 31.75 GiB of reads asked for 191 GiB instead of 127 GiB. RAM is now `clamp(4 x size("reads"), 64 GiB, 256 GiB)` — the floor and the 256 GiB ceiling are unchanged, and the `64GiB` static fallback is unchanged.
+
+Also bumps the `hash_override` UUID on the analyze template, which forces a one-time recompute of results cached against the previous template hash. As a side effect this de-collides the template from the identically-pinned one in mixcr-clonotyping, which the backend could previously treat as interchangeable.

--- a/.changeset/analyze-memory-no-double-count.md
+++ b/.changeset/analyze-memory-no-double-count.md
@@ -2,6 +2,15 @@
 "@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow": patch
 ---
 
-Analyze memory request no longer double-counts input size on top of the memory floor. The formula added a `4 x size("reads")` data term on top of the 64 GiB floor, but that floor is already a total-memory value, so the input was counted twice: 31.75 GiB of reads asked for 191 GiB instead of 127 GiB. RAM is now `clamp(4 x size("reads"), 64 GiB, 256 GiB)` — the floor and the 256 GiB ceiling are unchanged, and the `64GiB` static fallback is unchanged.
+Analyze counts input size once when sizing its memory request, cutting a run with
+31.75 GiB of reads from 191 GiB to 127 GiB.
 
-Also bumps the `hash_override` UUID on the analyze template, which forces a one-time recompute of results cached against the previous template hash. As a side effect this de-collides the template from the identically-pinned one in mixcr-clonotyping, which the backend could previously treat as interchangeable.
+The 64 GiB floor is already a total-memory value for the run, so adding a
+`4 x size("reads")` term on top of it counted the input twice. RAM is now
+`clamp(4 x size("reads"), 64 GiB, 256 GiB)`. The floor, the 256 GiB ceiling, and the
+`64GiB` static fallback all behave as before.
+
+The analyze template's `hash_override` UUID also changes, which forces a one-time
+recompute of results cached against the previous hash. That UUID was identical to the
+one in mixcr-clonotyping, letting the backend treat two different templates as
+interchangeable; the two are now distinct.

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -8,7 +8,8 @@
     "build": "shx rm -rf dist && pl-tengo build",
     "format": "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'",
     "do-pack": "rm -f *.tgz && pnpm pack && mv *.tgz package.tgz",
-    "check": "pl-tengo check"
+    "check": "pl-tengo check",
+    "test": "pl-tengo test"
   },
   "dependencies": {
     "@platforma-open/milaboratories.software-mixcr": "catalog:",

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -1,17 +1,18 @@
 // Single source of truth for the `mixcr analyze` memory request in this block.
 //
-// size("reads") is the stored (compressed) blob size of R1+R2 — metadata only, no
-// pre-exec pass — so the formula resolves where blob size is available and falls
-// back to the bare floor where it is not.
+//     mem = clamp(4 x size("reads"), baseMemGiB, 256 GiB)
 //
-//     mem = clamp(4 bytes/byte x size, baseMemGiB, 256 GiB)
+// baseMemGiB is a TOTAL-memory value for the run, so it acts as the lower bound rather
+// than a base to add data on top of. size("reads") is the stored (compressed) blob size
+// of R1+R2, read from metadata with no pre-exec pass, so the formula resolves where blob
+// size is available and falls back to the bare floor where it is not.
 
 exec := import("@platforma-sdk/workflow-tengo:exec")
 
 f := exec.formula
 
 // memFormula builds the fluent exec.formula node for `.resources({onCPU:{ram}})`.
-// The static fallback is a string quota, matching this block's existing behaviour.
+// staticFallback takes a quota string here ("64GiB"), not a byte count.
 memFormula := func(base) {
 	return f.size("reads").times(4).
 		between(f.gib(base), f.gib(256)).

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -1,0 +1,23 @@
+// Single source of truth for the `mixcr analyze` memory request in this block.
+//
+// size("reads") is the stored (compressed) blob size of R1+R2 — metadata only, no
+// pre-exec pass — so the formula resolves where blob size is available and falls
+// back to the bare floor where it is not.
+//
+//     mem = clamp(baseMemGiB + 4 bytes/byte x size, baseMemGiB, 256 GiB)
+
+exec := import("@platforma-sdk/workflow-tengo:exec")
+
+f := exec.formula
+
+// memFormula builds the fluent exec.formula node for `.resources({onCPU:{ram}})`.
+// The static fallback is a string quota, matching this block's existing behaviour.
+memFormula := func(base) {
+	return f.size("reads").times(4).plus(f.gib(base)).
+		between(f.gib(base), f.gib(256)).
+		staticFallback(string(base) + "GiB")
+}
+
+export {
+	memFormula: memFormula
+}

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -4,7 +4,7 @@
 // pre-exec pass — so the formula resolves where blob size is available and falls
 // back to the bare floor where it is not.
 //
-//     mem = clamp(baseMemGiB + 4 bytes/byte x size, baseMemGiB, 256 GiB)
+//     mem = clamp(4 bytes/byte x size, baseMemGiB, 256 GiB)
 
 exec := import("@platforma-sdk/workflow-tengo:exec")
 
@@ -13,7 +13,7 @@ f := exec.formula
 // memFormula builds the fluent exec.formula node for `.resources({onCPU:{ram}})`.
 // The static fallback is a string quota, matching this block's existing behaviour.
 memFormula := func(base) {
-	return f.size("reads").times(4).plus(f.gib(base)).
+	return f.size("reads").times(4).
 		between(f.gib(base), f.gib(256)).
 		staticFallback(string(base) + "GiB")
 }

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -22,10 +22,10 @@ _READS_31_75_GIB := 34091302912
 TestMemFormula := func() {
 	// mem = clamp(4 x size, 64 GiB, 256 GiB)
 
-	test.isEqual(_gib(127), _eval(mf.memFormula(64), _READS_31_75_GIB))  // was 191
-	test.isEqual(_gib(64),  _eval(mf.memFormula(64), 0))                 // floor, unchanged
-	test.isEqual(_gib(128), _eval(mf.memFormula(64), _gib(32)))          // was 192
-	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(64)))          // ceiling still binds
+	test.isEqual(_gib(127), _eval(mf.memFormula(64), _READS_31_75_GIB))  // linear region
+	test.isEqual(_gib(64),  _eval(mf.memFormula(64), 0))                 // floor binds
+	test.isEqual(_gib(128), _eval(mf.memFormula(64), _gib(32)))          // linear region
+	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(64)))          // ceiling binds
 	test.isEqual(_gib(64),  _eval(mf.memFormula(64), _gib(8)))           // 4 x 8 = 32 -> floor binds
 
 	test.isEqual("64GiB", f.fallbackOf(mf.memFormula(64)))

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -1,0 +1,34 @@
+test := import("@platforma-sdk/workflow-tengo:test")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+mf := import(":mem-formula")
+
+f := exec.formula
+
+_gib := func(n) { return n * 1073741824 }
+
+_eval := func(node, sizeBytes) {
+	fileName := "input.fastq.gz"
+	resolved := f.resolveAst(node, { "reads": [fileName] }, [fileName])
+	resolver := {
+		size:      func(files) { return sizeBytes },
+		lineCount: func(files) { return 0 }
+	}
+	return f.evaluateResource(resolved, resolver, "test")
+}
+
+// 31.75 GiB of reads, so the data term 4 x size is exactly 127 GiB.
+_READS_31_75_GIB := 34091302912
+
+TestMemFormulaToday := func() {
+	// CHARACTERIZATION: today's additive form,
+	//   mem = clamp(64 GiB + 4 x size, 64 GiB, 256 GiB)
+	// Task 4 changes these deliberately.
+
+	test.isEqual(_gib(191), _eval(mf.memFormula(64), _READS_31_75_GIB))  // 64 + 127
+	test.isEqual(_gib(64),  _eval(mf.memFormula(64), 0))                 // floor
+	test.isEqual(_gib(192), _eval(mf.memFormula(64), _gib(32)))          // 64 + 128
+	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(64)))          // 64 + 256 -> ceiling
+
+	// The fallback is a STRING in this block, unlike mixcr-clonotyping.
+	test.isEqual("64GiB", f.fallbackOf(mf.memFormula(64)))
+}

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -19,16 +19,14 @@ _eval := func(node, sizeBytes) {
 // 31.75 GiB of reads, so the data term 4 x size is exactly 127 GiB.
 _READS_31_75_GIB := 34091302912
 
-TestMemFormulaToday := func() {
-	// CHARACTERIZATION: today's additive form,
-	//   mem = clamp(64 GiB + 4 x size, 64 GiB, 256 GiB)
-	// Task 4 changes these deliberately.
+TestMemFormula := func() {
+	// mem = clamp(4 x size, 64 GiB, 256 GiB)
 
-	test.isEqual(_gib(191), _eval(mf.memFormula(64), _READS_31_75_GIB))  // 64 + 127
-	test.isEqual(_gib(64),  _eval(mf.memFormula(64), 0))                 // floor
-	test.isEqual(_gib(192), _eval(mf.memFormula(64), _gib(32)))          // 64 + 128
-	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(64)))          // 64 + 256 -> ceiling
+	test.isEqual(_gib(127), _eval(mf.memFormula(64), _READS_31_75_GIB))  // was 191
+	test.isEqual(_gib(64),  _eval(mf.memFormula(64), 0))                 // floor, unchanged
+	test.isEqual(_gib(128), _eval(mf.memFormula(64), _gib(32)))          // was 192
+	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(64)))          // ceiling still binds
+	test.isEqual(_gib(64),  _eval(mf.memFormula(64), _gib(8)))           // 4 x 8 = 32 -> floor binds
 
-	// The fallback is a STRING in this block, unlike mixcr-clonotyping.
 	test.isEqual("64GiB", f.fallbackOf(mf.memFormula(64)))
 }

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -15,6 +15,8 @@ text := import("text")
 
 json := import("json")
 
+memf := import(":mem-formula")
+
 mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:memory-from-limits")
 
 self.defineOutputs("qc", "reports", "log", "clns")
@@ -167,15 +169,12 @@ self.body(func(inputs) {
 	// resolves on backends without getBlobSize too: the formula falls back to the 64 GiB floor,
 	// and constant/static values are used as-is.
 	//     mem = clamp(64 GiB + 4 bytes/byte * size, 64 GiB, 256 GiB)
-	f := exec.formula
 	ram := undefined
 	if !is_undefined(perProcessMemGB) {
 		ram = string(perProcessMemGB) + "GiB"
 	} else {
 		baseMemGiB := 64
-		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB)).
-			between(f.gib(baseMemGiB), f.gib(256)).
-			staticFallback(string(baseMemGiB) + "GiB")
+		ram = memf.memFormula(baseMemGiB)
 	}
 	mixcrCmdBuilder.resources({
 		onCPU: {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override D70EDB25-6FF6-4615-966D-B79B04B5751C
+//tengo:hash_override BE6EBF10-B660-4B96-AAA5-B73959F6BFD0
 
 // mixcr analyze
 
@@ -168,7 +168,8 @@ self.body(func(inputs) {
 	// decompressing. cpu is a constant and the ram formula carries a .staticFallback, so this
 	// resolves on backends without getBlobSize too: the formula falls back to the 64 GiB floor,
 	// and constant/static values are used as-is.
-	//     mem = clamp(64 GiB + 4 bytes/byte * size, 64 GiB, 256 GiB)
+	//     mem = clamp(4 bytes/byte * size, 64 GiB, 256 GiB)
+	// The 64 GiB floor is a TOTAL-memory value, not a base to add data on top of.
 	ram := undefined
 	if !is_undefined(perProcessMemGB) {
 		ram = string(perProcessMemGB) + "GiB"

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -163,13 +163,15 @@ self.body(func(inputs) {
 		// }
 
 	// RAM per process: an explicit "Advanced Settings" override (a static request), or sized
-	// from the input reads' file size. size("reads") sums the stored (compressed) blob size of
-	// R1+R2 via getBlobSize (a metadata read, no pre-exec), so it tracks input volume without
-	// decompressing. cpu is a constant and the ram formula carries a .staticFallback, so this
-	// resolves on backends without getBlobSize too: the formula falls back to the 64 GiB floor,
-	// and constant/static values are used as-is.
-	//     mem = clamp(4 bytes/byte * size, 64 GiB, 256 GiB)
-	// The 64 GiB floor is a TOTAL-memory value, not a base to add data on top of.
+	// from the input reads' file size.
+	//     mem = clamp(4 * size("reads"), 64 GiB, 256 GiB)
+	// size("reads") sums the stored (compressed) blob size of R1+R2 via getBlobSize — a
+	// metadata read, no pre-exec — so it tracks input volume without decompressing. The
+	// 64 GiB floor is a TOTAL-memory value, so it acts as the lower bound rather than a
+	// base to add data on top of.
+	// cpu is a constant and the ram formula carries a .staticFallback, so this resolves on
+	// backends without getBlobSize too: the formula falls back to the 64 GiB floor, and
+	// constant/static values are used as-is.
 	ram := undefined
 	if !is_undefined(perProcessMemGB) {
 		ram = string(perProcessMemGB) + "GiB"


### PR DESCRIPTION
## What

The analyze memory request counted the input size twice. The 64 GiB floor is a **total**-memory value for the run, but the formula added a data term on top of it:

```
before:  mem = clamp(64 GiB + 4 x size("reads"), 64 GiB, 256 GiB)
after:   mem = clamp(4 x size("reads"),          64 GiB, 256 GiB)
```

No `max()` is needed in its place: `.between(base, 256)` already supplies `base` as the lower bound. That bound was dead code until now, because an additive term can never fall below the floor it was added to.

## Effect

| reads | before | after |
|---|---|---|
| 31.75 GiB | 191 GiB | **127 GiB** |
| 32 GiB | 192 GiB | **128 GiB** |
| 8 GiB | 96 GiB | **64 GiB** (floor binds) |
| empty | 64 GiB | 64 GiB |
| 64 GiB | 256 GiB (cap) | 256 GiB (cap) |

Large samples request materially less; small samples stay floor-bound. The 64 GiB floor, the 256 GiB ceiling, and the `"64GiB"` static fallback all behave exactly as before — the fallback stays a quota string rather than a byte count, since changing it would be an untested behaviour change beyond this fix.

## Structure

Two commits, kept separate on purpose:

1. **Extract** the arithmetic into `mem-formula.lib.tengo` behind a characterization test pinning today's values, and add the `test` script this repo lacked. Computes identical results.
2. **Flip** the behaviour. This commit's test diff is the whole record of what moved — read it alone and you see 191 become 127.

The lib is intentionally *not* a copy of the one in `mixcr-clonotyping`: this block has a single floor and a string fallback, that one has three floors and a byte-count fallback. They are separate repositories and cannot share code regardless.

## hash_override UUID bump

`mixcr-analyze.tpl.tengo` carries a pinned `//tengo:hash_override`, bumped here to a fresh UUID. This forces a one-time recompute of results cached against the old hash.

The previous value was shared byte-for-byte with `mixcr-clonotyping`, whose body differs by several hundred lines. Two templates pinning one UUID are interchangeable as far as the backend is concerned, which is the hazard the compiler warns about for this option. Both repos now pin distinct fresh values.

**This does not close out the CID work.** Commit `1bc35a6` on `mzueva/fix-library-failure` diagnosed this collision and fixed it as three parts: the UUID, reference-library routing, and a canonical-JSON helper (Tengo's `json.encode` iterates Go map keys in random order, so identical values produced unstable CIDs). Only the UUID is addressed here. The other two remain unmerged, and that branch is now well behind `main`.

## Testing

`pnpm exec pl-tengo test` passes `TestMemFormula`, confirmed failing before the fix with `expect: 136365211648, got 205084688384` — so it is not vacuous. `pnpm run build:dev-no-software` and `pnpm exec pl-tengo check` are clean, and `pnpm install` produced no lockfile drift.

**No live run yet** — this is unit- and build-level verification only. A meaningful live check needs an input the backend has never computed, or a previously-failed one. Memory and CPU go into `metaExtra` and are excluded from a resource's canonical ID, specifically so dedup reuses results across differing grants, so re-running an already-successful sample cannot surface a new grant however correct the change is.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts the analyze RAM calculation into a tested library, removes the additive 64 GiB term so input size is counted once, and changes the template hash override to invalidate the prior cache identity.

- **Memory formula** — the resource-sizing expression; changed from `clamp(64 GiB + 4 × reads size, 64 GiB, 256 GiB)` to `clamp(4 × reads size, 64 GiB, 256 GiB)`.
- **Floor** — the minimum requested RAM; remains 64 GiB but now acts solely as the clamp’s lower bound.
- **Ceiling** — the maximum requested RAM; remains 256 GiB.
- **Static fallback** — the quota used when dynamic size metadata cannot be resolved; remains the string `"64GiB"`.
- **Reads size** — the stored compressed size of inputs tagged `reads`; remains the dynamic input to the formula.
- **Memory override** — the explicit per-process RAM setting; continues to bypass dynamic sizing.
- **`hash_override`** — the template cache-identity override; changed to a fresh UUID to force recomputation and avoid sharing the prior identity.
- **Formula test** — the new unit test covers the floor, linear range, ceiling, zero-sized input, and static fallback.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/mem-formula.lib.tengo | Introduces the shared analyze memory formula with the intended 64 GiB floor, 256 GiB ceiling, and unchanged static fallback. |
| workflow/src/mem-formula.test.tengo | Adds focused coverage for the formula’s floor, linear region, ceiling, zero input, and fallback representation. |
| workflow/src/mixcr-analyze.tpl.tengo | Replaces the inline double-counting formula with the extracted helper and assigns a fresh template hash override while preserving explicit memory overrides. |
| workflow/package.json | Exposes the existing Tengo test runner through the package test script. |
| .changeset/analyze-memory-no-double-count.md | Documents the corrected sizing behavior and cache-identity change for a patch release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A{Per-process memory override set?}
    A -->|Yes| B[Use override as GiB quota]
    A -->|No| C[Read stored size of inputs tagged reads]
    C --> D[Multiply size by 4]
    D --> E[Clamp between 64 GiB and 256 GiB]
    C -. size unavailable .-> F[Use static fallback 64GiB]
    B --> G[Set analyze CPU RAM resource]
    E --> G
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["MILAB-6721: clarify memory formula comme..."](https://github.com/platforma-open/mixcr-amplicon-alignment/commit/910fff5e79ca43e38d738985de2aa82d70eb4400) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50049293)</sub>

<!-- /greptile_comment -->