### PR TITLE
MILAB-6731: fix FASTA gene-name derivation and CDR3 location

### DIFF
--- a/.changeset/cdr3-search-offset-escalation.md
+++ b/.changeset/cdr3-search-offset-escalation.md
@@ -1,0 +1,17 @@
+---
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.ui": patch
+---
+
+A reference that begins mid-FR1 no longer loses its CDR3.
+
+The CDR3 is located with a cysteine-anchored regex applied from a fixed offset of 80
+residues, which exists to skip the conserved FR1 cysteine. A reference covering only the
+amplified region rather than the full domain begins mid-FR1, which pulls its CDR3
+cysteine ahead of that offset and hides it. Strict parsing then rejected the reference
+outright; lenient parsing reported success and split V from J at two-thirds of the
+sequence — a guess that for the synthetic-nanobody reference put the boundary at 202 nt
+instead of 253, with nothing shown in the UI to say the boundary was guessed.
+
+The offset is now the primary search rather than the only one: when it finds nothing,
+the whole translated sequence is searched before giving up. Every nucleotide reference
+that resolved before resolves to the identical boundary.

--- a/.changeset/fasta-gene-name-sanitize.md
+++ b/.changeset/fasta-gene-name-sanitize.md
@@ -1,0 +1,16 @@
+---
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.ui": patch
+---
+
+Reference FASTA headers with a description no longer break the reference library.
+
+Gene names are derived from the FASTA header, and repseqio addresses each gene as the
+fragment of a `file://<file>#<geneName>` URI — where spaces and most punctuation are
+illegal. A header such as `>S1-F4_VH parental anti-CD98hc heavy variable domain (…)`
+was passed through in full, so building the library failed with
+`URISyntaxException: Illegal character in fragment` after the UI had already reported
+the input as valid.
+
+The header is now reduced to its first whitespace-delimited field with characters
+outside `[A-Za-z0-9_.-]` removed, and a counter is appended when two headers reduce to
+the same token, so distinct references cannot silently merge into one gene.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
         version: 1.3.1
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
+        version: 1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)(vite@8.0.16(@types/node@25.0.2)(esbuild@0.27.1)(yaml@2.8.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -261,6 +261,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)
 
   workflow:
     dependencies:
@@ -2291,9 +2294,6 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2886,10 +2886,6 @@ packages:
   canonicalize@2.1.0:
     resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
     hasBin: true
-
-  chai@6.2.1:
-    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
-    engines: {node: '>=18'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3894,11 +3890,6 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3950,9 +3941,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -4081,10 +4069,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -4125,10 +4109,6 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -4528,10 +4508,6 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -4539,10 +4515,6 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
-
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -7159,36 +7131,6 @@ snapshots:
       commander: 15.0.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))':
-    dependencies:
-      '@milaboratories/computable': 2.9.8
-      '@milaboratories/pl-client': 3.14.4
-      '@milaboratories/pl-middle-layer': 1.66.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)
-      '@milaboratories/pl-tree': 1.13.3
-      '@platforma-sdk/model': 1.80.10
-      '@vitest/coverage-istanbul': 4.1.8(vitest@4.0.18(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
-      vitest: 4.1.8(@types/node@25.0.2)(@vitest/coverage-istanbul@4.1.8)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - '@bytecodealliance/preview2-shim'
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@types/node'
-      - '@vitest/browser-playwright'
-      - '@vitest/browser-preview'
-      - '@vitest/browser-webdriverio'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - aws-crt
-      - bare-abort-controller
-      - bare-buffer
-      - encoding
-      - happy-dom
-      - jsdom
-      - msw
-      - react-native-b4a
-      - supports-color
-      - vite
-
   '@platforma-sdk/test@1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)(vite@8.0.16(@types/node@25.0.2)(esbuild@0.27.1)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.8
@@ -7196,7 +7138,7 @@ snapshots:
       '@milaboratories/pl-middle-layer': 1.66.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.2)
       '@milaboratories/pl-tree': 1.13.3
       '@platforma-sdk/model': 1.80.10
-      '@vitest/coverage-istanbul': 4.1.8(vitest@4.1.8)
+      '@vitest/coverage-istanbul': 4.1.8(vitest@4.0.18(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
       vitest: 4.1.8(@types/node@25.0.2)(@vitest/coverage-istanbul@4.1.8)(vite@8.0.16(@types/node@25.0.2)(esbuild@0.27.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -7885,8 +7827,6 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -8001,30 +7941,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@4.1.8(vitest@4.1.8)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@istanbuljs/schema': 0.1.3
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.3
-      tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.0.2)(@vitest/coverage-istanbul@4.1.8)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/expect@4.0.18':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
-      chai: 6.2.1
-      tinyrainbow: 3.0.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -8043,14 +7967,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.8(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.0.2)(esbuild@0.27.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.8
@@ -8061,7 +7977,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -8097,7 +8013,7 @@ snapshots:
   '@vitest/utils@4.0.18':
     dependencies:
       '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -8596,8 +8512,6 @@ snapshots:
 
   canonicalize@2.1.0: {}
 
-  chai@6.2.1: {}
-
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -9024,10 +8938,6 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -9558,8 +9468,6 @@ snapshots:
   nan@2.24.0:
     optional: true
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0: {}
@@ -9593,8 +9501,6 @@ snapshots:
       path-key: 2.0.1
 
   object-assign@4.1.1: {}
-
-  obug@2.1.1: {}
 
   obug@2.1.3: {}
 
@@ -9734,8 +9640,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
@@ -9776,12 +9680,6 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10271,19 +10169,12 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
-
-  tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -10445,11 +10336,11 @@ snapshots:
   vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.1
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
       rollup: 4.53.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.0.2
       fsevents: 2.3.3
@@ -10481,14 +10372,14 @@ snapshots:
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
       vite: 7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -10505,34 +10396,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vitest@4.1.8(@types/node@25.0.2)(@vitest/coverage-istanbul@4.1.8)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.0.2
-      '@vitest/coverage-istanbul': 4.1.8(vitest@4.0.18(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.8(@types/node@25.0.2)(@vitest/coverage-istanbul@4.1.8)(vite@8.0.16(@types/node@25.0.2)(esbuild@0.27.1)(yaml@2.8.2)):
     dependencies:
@@ -10558,7 +10421,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.2
-      '@vitest/coverage-istanbul': 4.1.8(vitest@4.1.8)
+      '@vitest/coverage-istanbul': 4.1.8(vitest@4.0.18(@types/node@25.0.2)(lightningcss@1.32.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - msw
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "type-check": "ts-builder type-check --target block-ui",
     "do-pack": "rm -f *.tgz && pnpm pack && mv *.tgz package.tgz",
     "fmt": "ts-builder format",
-    "check": "ts-builder check --target block-ui"
+    "check": "ts-builder check --target block-ui",
+    "test": "vitest run"
   },
   "dependencies": {
     "@milaboratories/helpers": "catalog:",
@@ -27,7 +28,8 @@
     "@milaboratories/ts-builder": "catalog:",
     "@milaboratories/ts-configs": "catalog:",
     "@types/wicg-file-system-access": "catalog:",
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "@types/node": "*",

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { parseFasta, parseFastaRecords } from "./parseFasta";
+
+/**
+ * The S1-F4 parental anti-CD98hc VH domain, 375 nt. A real reference: full-length,
+ * a multiple of three, and its conserved cysteine sits past the CDR3 search offset,
+ * so it reaches the gene-derivation code rather than failing validation first.
+ */
+const VH_375NT = [
+  "CAGGTGCAGCTGGTGCAGAGCGGGGCAGAGGTGAAGAAGCCCGGAGCCAGCGTGAAAGTG",
+  "AGCTGCAAGGCCAGCGGCTACACCTTCACGAGCTATTACATGCACTGGGTGAGGCAGGCA",
+  "CCCGGTCAGGGCCTGGAGTGGATGGGCATCATCAACCCCTCTGGCGGCAGCACCAGTTAC",
+  "GCCCAGAAGTTCCAGGGTAGGGTGACCATGACCAGGGACACCAGTACCTCCACCGTGTAC",
+  "ATGGAGCTGAGCAGCCTGAGGAGCGAGGACACCGCCGTGTATTACTGCGCCAGGGGCTAC",
+  "TACGACATTCTCACTGGTTCTCGTCCCATCTTCTTCGACATTTGGGGGCAGGGCACTATG",
+  "GTGACCGTGAGCTCT",
+].join("\n");
+
+/** The header of that reference as the studies library actually ships it. */
+const DESCRIPTIVE_HEADER =
+  "S1-F4_VH parental anti-CD98hc heavy variable domain, nucleotide (recovered by " +
+  "base-consensus from the input-pool reads SRR37934230; framework matches the " +
+  "yeast-display construct and translates to the PDB 7DF1 VH); WT HCDR3 " +
+  "GYYDILTGSRPIFFDI, 10 randomized positions YYDILGSRPI";
+
+function fasta(...records: [header: string, sequence: string][]): string {
+  return records.map(([h, s]) => `>${h}\n${s}`).join("\n");
+}
+
+/** First line of a single-record FASTA string, without the leading ">". */
+function geneName(fastaString: string | undefined): string {
+  return (fastaString ?? "").split("\n")[0]?.replace(/^>/, "") ?? "";
+}
+
+function geneNames(fastaString: string | undefined): string[] {
+  return (fastaString ?? "")
+    .split("\n")
+    .filter((l) => l.startsWith(">"))
+    .map((l) => l.slice(1));
+}
+
+describe("parseFasta gene naming", () => {
+  it("strips a descriptive header down to its identifier", () => {
+    const result = parseFasta(fasta([DESCRIPTIVE_HEADER, VH_375NT]));
+
+    expect(result.isValid).toBe(true);
+    expect(geneName(result.vGenes)).toBe("S1-F4_VH_Vgene");
+    expect(geneName(result.jGenes)).toBe("S1-F4_VH_Jgene");
+  });
+
+  // The invariant behind the bug: repseqio addresses a gene as the fragment of a
+  // `file://<file>#<geneName>` URI, so an illegal fragment character fails the whole
+  // library build — far from here, and only after validation has reported success.
+  it("derives gene names that are legal URI fragments", () => {
+    const headers = [
+      DESCRIPTIVE_HEADER,
+      "plain_name",
+      "with.dots-and_underscores",
+      "trailing spaces and (parens), semicolons; commas",
+    ];
+
+    for (const header of headers) {
+      const result = parseFasta(fasta([header, VH_375NT]));
+      expect(result.isValid).toBe(true);
+
+      for (const name of [geneName(result.vGenes), geneName(result.jGenes)]) {
+        expect(name).not.toMatch(/[^A-Za-z0-9_.-]/);
+        expect(() => new URL(`file://vGene.fasta#${name}`)).not.toThrow();
+      }
+    }
+  });
+
+  it("keeps a header that is already a single token", () => {
+    const result = parseFasta(fasta(["CR9114_HC_WT", VH_375NT]));
+
+    expect(geneName(result.vGenes)).toBe("CR9114_HC_WT_Vgene");
+  });
+
+  it("takes the field before a pipe, then its first word", () => {
+    const result = parseFasta(
+      fasta(["emibetuzumab_VH_WT_nt | parental VH nucleotide (construct)", VH_375NT]),
+    );
+
+    expect(geneName(result.vGenes)).toBe("emibetuzumab_VH_WT_nt_Vgene");
+  });
+
+  // Truncation alone would collapse these into one gene name, trading a loud failure
+  // for a silent wrong answer.
+  it("disambiguates headers that reduce to the same token", () => {
+    const result = parseFasta(
+      fasta(["shared_prefix first variant", VH_375NT], ["shared_prefix second variant", VH_375NT]),
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(geneNames(result.vGenes)).toEqual(["shared_prefix_Vgene", "shared_prefix_2_Vgene"]);
+    expect(geneNames(result.jGenes)).toEqual(["shared_prefix_Jgene", "shared_prefix_2_Jgene"]);
+  });
+
+  it("falls back to a default name when nothing usable survives", () => {
+    const result = parseFasta(fasta(["((( ;;; )))", VH_375NT]));
+
+    expect(result.isValid).toBe(true);
+    expect(geneName(result.vGenes)).toBe("ref_Vgene");
+    expect(geneName(result.jGenes)).toBe("ref_Jgene");
+  });
+});
+
+describe("parseFasta validation", () => {
+  it("accepts a full-length reference and splits it into V and J", () => {
+    const result = parseFasta(fasta(["ref", VH_375NT]));
+
+    expect(result.isValid).toBe(true);
+    // The split is a partition of the sequence: V ends where J begins.
+    const v = (result.vGenes ?? "").split("\n").slice(1).join("");
+    const j = (result.jGenes ?? "").split("\n").slice(1).join("");
+    expect(v.length + j.length).toBe(375);
+  });
+
+  it("rejects amino-acid input as invalid DNA", () => {
+    const result = parseFasta(fasta(["aa_ref", "EVQLVESGGGLVKPGGSLKLSCAASGFTLTSYTMNWVRQ"]));
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain("Invalid DNA characters");
+  });
+
+  it("rejects a sequence that is not a multiple of three", () => {
+    const result = parseFasta(fasta(["ref", VH_375NT.replace(/\n/g, "") + "A"]));
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain("not a multiple of 3");
+  });
+
+  it("reports an empty FASTA", () => {
+    expect(parseFasta("").isValid).toBe(false);
+    expect(parseFasta("   ").error).toBe("FASTA content is empty");
+  });
+});
+
+describe("parseFastaRecords", () => {
+  it("reads a headerless sequence as one record", () => {
+    const records = parseFastaRecords("ACGT\nACGT");
+
+    expect(records).toEqual([{ header: "", sequence: "ACGTACGT" }]);
+  });
+
+  it("splits multiple records and joins wrapped sequence lines", () => {
+    const records = parseFastaRecords(">a\nACGT\nTTTT\n>b\nGGGG");
+
+    expect(records).toEqual([
+      { header: "a", sequence: "ACGTTTTT" },
+      { header: "b", sequence: "GGGG" },
+    ]);
+  });
+});

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -103,6 +103,34 @@ describe("parseFasta gene naming", () => {
     expect(geneName(result.vGenes)).toBe("ref_Vgene");
     expect(geneName(result.jGenes)).toBe("ref_Jgene");
   });
+
+  // The fallback has to share the counter too. A multi-record FASTA only requires
+  // headers to be non-empty, not usable, so several records can sanitize away — and
+  // two records both named `ref_Vgene` would let repseqio index one over the other.
+  it("disambiguates records whose headers all sanitize away", () => {
+    const result = parseFasta(
+      fasta(["(((", VH_375NT], [";;;", VH_375NT], ["!!!", VH_375NT]),
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(geneNames(result.vGenes)).toEqual(["ref_Vgene", "ref_2_Vgene", "ref_3_Vgene"]);
+    expect(geneNames(result.jGenes)).toEqual(["ref_Jgene", "ref_2_Jgene", "ref_3_Jgene"]);
+  });
+
+  it("keeps every gene name distinct across a mixed batch", () => {
+    const result = parseFasta(
+      fasta(
+        ["ref other words", VH_375NT],
+        ["(((", VH_375NT],
+        ["ref", VH_375NT],
+        ["real_name", VH_375NT],
+      ),
+    );
+
+    const names = geneNames(result.vGenes);
+    expect(names).toHaveLength(4);
+    expect(new Set(names).size).toBe(4);
+  });
 });
 
 describe("parseFasta validation", () => {

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -108,9 +108,7 @@ describe("parseFasta gene naming", () => {
   // headers to be non-empty, not usable, so several records can sanitize away — and
   // two records both named `ref_Vgene` would let repseqio index one over the other.
   it("disambiguates records whose headers all sanitize away", () => {
-    const result = parseFasta(
-      fasta(["(((", VH_375NT], [";;;", VH_375NT], ["!!!", VH_375NT]),
-    );
+    const result = parseFasta(fasta(["(((", VH_375NT], [";;;", VH_375NT], ["!!!", VH_375NT]));
 
     expect(result.isValid).toBe(true);
     expect(geneNames(result.vGenes)).toEqual(["ref_Vgene", "ref_2_Vgene", "ref_3_Vgene"]);

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -51,6 +51,11 @@ describe("parseFasta gene naming", () => {
   // The invariant behind the bug: repseqio addresses a gene as the fragment of a
   // `file://<file>#<geneName>` URI, so an illegal fragment character fails the whole
   // library build — far from here, and only after validation has reported success.
+  //
+  // Asserted as a character-set constraint rather than by constructing a URL: repseqio
+  // parses with Java's `java.net.URI`, which follows RFC 2396 and throws on an illegal
+  // fragment, whereas JS `new URL()` is WHATWG and percent-encodes instead of throwing —
+  // it accepts every header below, including the 275-character one that caused the bug.
   it("derives gene names that are legal URI fragments", () => {
     const headers = [
       DESCRIPTIVE_HEADER,
@@ -65,7 +70,6 @@ describe("parseFasta gene naming", () => {
 
       for (const name of [geneName(result.vGenes), geneName(result.jGenes)]) {
         expect(name).not.toMatch(/[^A-Za-z0-9_.-]/);
-        expect(() => new URL(`file://vGene.fasta#${name}`)).not.toThrow();
       }
     }
   });

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -16,6 +16,42 @@ const VH_375NT = [
   "GTGACCGTGAGCTCT",
 ].join("\n");
 
+/**
+ * The synthetic nanobody parental clone from `2026-07-synthetic-nanobody-abaumannii`,
+ * 303 nt. This is the amplified region, so it begins mid-FR1 at `…RLSCAAS` rather than
+ * at the domain N-terminus: 101 aa with the conserved CDR3 cysteine at residue 78, ahead
+ * of the search offset. `N` marks a randomized CDR position (CDR1/CDR2/CDR3 = 7/7/9 aa).
+ */
+const VHH_303NT = [
+  "CGTTTGTCTTGTGCTGCGTCCGGCNNNNNNNNNNNNNNNNNNNNNATGGGGTGGTTTCGC",
+  "CAGGCACCTGGCAAAGAACGTGAATTTGTTGCAGCAATTAGTNNNNNNNNNNNNNNNNNN",
+  "NNNTACTACGCAGATTCCGTTAAGGGACGCTTCACAATTTCGCGCGACAATGCAAAAAAT",
+  "ACCGTGTATTTACAAATGAATTCGTTGAAGCCGGAAGACACTGCGACTTATTATTGTGCG",
+  "NNNNNNNNNNNNNNNNNNNNNNNNNNNTATTGGGGACAAGGCACACAAGTCACGGTCTCC",
+  "GTG",
+].join("\n");
+
+/**
+ * `KU641040.1` from the macaque anti-SIV gp140 panel, 738 nt. A single-chain Fv, so one
+ * record carries two variable domains and therefore two CDR3s — the VL's at residue 88
+ * and the VH's at 212. The block resolves this to the first CDR3 past the offset.
+ */
+const SCFV_738NT = [
+  "ATGCTGACTCAGCCCCACTCTGTGTCGGGGTCTCCGGGGCAGACGGTCACCATCTCCTGC",
+  "ACCCGCAGCAGTGGCTACATTGGCAGCAACTCTGTGTACTGGTACCAGCAGCGGCCGGGC",
+  "AGCGCCCCCACCACTGTGATTTACAAAGATAATCAAAGACCCTCTGGGATCCCTGATCGG",
+  "TTCTCTGGCTCCATCGACAGCTCCTCCAACTCTGCCTCCCTCACCATCTCTGGACTGAAG",
+  "TCTGAGGACGAGGCTGACTACTACTGTCAGTCTTATGACAGCACTTATGATGTGTTTTTC",
+  "GGAGGAGGCACCAAGCTGACCGTCCTAGGCGGTGGTTCCTCTAGATCTTCCGAGGTGCAG",
+  "CTGGTGCAGTCTGGGACTGAGGTGAGGAAGCCTGGGGCCTCAGTGAAGGTTTCCTGCCAG",
+  "GCTTCTGGCATCAGCTTCGACAGATATGCTCTCACCTGGGTGCGACAGGTCCCTGGACAA",
+  "GGGCTTGAGTGGATGGGATCGATCATCCCTCTTGCTAGCATGACAAAGTACGCAGAGAAG",
+  "TTCCAGGGCAGAGTCACGATAACCGCGGATACGTCCAGAGGGACAGCCTACATGGAGCTG",
+  "AGTAGCCTGACATCTGAGGACACGGCCGTTTATTATTGTGCGAGACCCGGGGACGACAGT",
+  "GGGGCCTTTGACCTCTGGGGCCAGGGAGCCCTGGTCACCGTCTCCTCAGCCTCCACCAAG",
+  "GGCCCATCGGTCACTAGT",
+].join("\n");
+
 /** The header of that reference as the studies library actually ships it. */
 const DESCRIPTIVE_HEADER =
   "S1-F4_VH parental anti-CD98hc heavy variable domain, nucleotide (recovered by " +
@@ -30,6 +66,11 @@ function fasta(...records: [header: string, sequence: string][]): string {
 /** First line of a single-record FASTA string, without the leading ">". */
 function geneName(fastaString: string | undefined): string {
   return (fastaString ?? "").split("\n")[0]?.replace(/^>/, "") ?? "";
+}
+
+/** Sequence body of a single-record V or J FASTA string, without the header line. */
+function geneSequence(fastaString: string | undefined): string {
+  return (fastaString ?? "").split("\n").slice(1).join("");
 }
 
 function geneNames(fastaString: string | undefined): string[] {
@@ -163,6 +204,56 @@ describe("parseFasta validation", () => {
   it("reports an empty FASTA", () => {
     expect(parseFasta("").isValid).toBe(false);
     expect(parseFasta("   ").error).toBe("FASTA content is empty");
+  });
+});
+
+describe("parseFasta CDR3 location", () => {
+  // The two tests below pin behaviour that already holds. They exist because the search
+  // offset looks arbitrary and invites removal: across the 137 nucleotide references in
+  // platforma-studies-library, searching the whole translated sequence instead anchors on
+  // the FR1 cysteine in roughly half of them, and anchoring on the last match moves the
+  // boundary in about ninety. Whatever finds the CDR3 has to keep these two intact.
+
+  it("anchors on the CDR3 cysteine rather than the FR1 cysteine", () => {
+    const result = parseFasta(fasta(["s1f4", VH_375NT]));
+
+    expect(result.isValid).toBe(true);
+    // S1-F4 carries cysteines at residues 21 (FR1) and 95 (CDR3). Anchoring on 21 would
+    // cut V at 85 nt and hand the remaining 290 nt — nearly the whole domain — to J.
+    expect(geneSequence(result.vGenes)).toHaveLength(315);
+    expect(geneSequence(result.jGenes)).toHaveLength(60);
+  });
+
+  it("anchors on the first CDR3 when one record carries two variable domains", () => {
+    const result = parseFasta(fasta(["scfv", SCFV_738NT]));
+
+    expect(result.isValid).toBe(true);
+    // An scFv has a CDR3 per domain — here at residues 88 and 212, the light chain first.
+    // The boundary belongs to the first; taking the last would move V by 372 nt.
+    expect(geneSequence(result.vGenes)).toHaveLength(295);
+    expect(geneSequence(result.jGenes)).toHaveLength(443);
+  });
+
+  // A reference covering only the amplified region starts mid-FR1, which pulls its CDR3
+  // cysteine ahead of the offset. The offset then hides the one cysteine that matters.
+  it("locates a CDR3 that sits ahead of the search offset", () => {
+    const result = parseFasta(fasta(["nanobody", VHH_303NT]));
+
+    expect(result.isValid).toBe(true);
+    expect(geneSequence(result.vGenes)).toHaveLength(253);
+    expect(geneSequence(result.jGenes)).toHaveLength(50);
+  });
+
+  // The lenient path is the one that reaches a user: BuildLibraryPanel parses with
+  // `lenient: true`, and on a miss it splits at two-thirds of the sequence and reports
+  // success. For this reference that guess puts the boundary at 202 nt instead of 253 —
+  // 51 nt of V handed to the J gene, with nothing shown in the UI to say so.
+  it("splits a mid-FR1 reference at its real boundary in lenient mode", () => {
+    const result = parseFasta(fasta(["nanobody", VHH_303NT]), undefined, true);
+
+    expect(result.isValid).toBe(true);
+    expect(geneSequence(result.vGenes)).toHaveLength(253);
+    expect(geneSequence(result.jGenes)).toHaveLength(50);
   });
 });
 

--- a/ui/src/utils/parseFasta.ts
+++ b/ui/src/utils/parseFasta.ts
@@ -183,14 +183,24 @@ export function parseFasta(
     const validationRegex =
       /C([ACDEFGHIKLMNPQRSTVWYX]{4,50}[FWYLIX])[ACDEFGHIKLMNPQRSTVWYX]{0,5}G[ACDEFGHIKLMNPQRSTVWYX]G/;
 
-    // Only search from position 80 onwards (240 nucleotides)
-    const searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
-    const sequenceToSearch = translatedSequence.substring(searchStartPosition);
+    // The offset exists to skip the conserved FR1 cysteine, which sits near residue 20 and
+    // would otherwise anchor the split at the start of the domain. That holds for a
+    // reference beginning at the domain N-terminus; one covering only the amplified region
+    // begins mid-FR1, which pulls its CDR3 cysteine ahead of the offset and hides it.
+    //
+    // So escalate rather than derive: keep the offset as the primary search — it resolves
+    // the FR1 cysteine correctly for all but one of the nucleotide references we have —
+    // and widen to the whole translation only when it finds nothing.
+    let searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
+    let match = validationRegex.exec(translatedSequence.substring(searchStartPosition));
+    if (!match) {
+      searchStartPosition = 0;
+      match = validationRegex.exec(translatedSequence);
+    }
 
-    const match = validationRegex.exec(sequenceToSearch);
     if (!match) {
       if (!lenient) {
-        const error = `${recordIdentifier}: Translated sequence does not contain CDR3 after position ${searchStartPosition}`;
+        const error = `${recordIdentifier}: Translated sequence does not contain a CDR3`;
         return { isValid: false, error };
       }
       // In lenient mode, split at 2/3 of the sequence as a rough V/J boundary estimate

--- a/ui/src/utils/parseFasta.ts
+++ b/ui/src/utils/parseFasta.ts
@@ -249,6 +249,34 @@ export function parseFasta(
   };
 }
 
+/**
+ * Reduce a FASTA header to a token usable as a repseqio gene name.
+ *
+ * repseqio addresses each gene as the fragment of a `file://<file>#<geneName>` URI, so a
+ * gene name may only contain characters that are legal in a URI fragment. FASTA headers
+ * routinely carry a descriptive tail after the identifier, which — appended verbatim —
+ * makes repseqio fail with `URISyntaxException: Illegal character in fragment`, several
+ * layers below the UI and long after this validation has reported success.
+ *
+ * Keeps the first whitespace-delimited field ahead of any `|`, drops characters outside
+ * `[A-Za-z0-9_.-]`, and appends a counter when two headers reduce to the same token, so
+ * distinct records can never collapse onto one gene name.
+ *
+ * A header can sanitize away entirely — punctuation only, or a non-Latin script. Those
+ * fall back to `DEFAULT_GENE_NAME_BASE` and go through the same counter, because two
+ * unusable headers are exactly as capable of colliding as two similar ones.
+ */
+function uniqueGeneNameToken(header: string, used: Set<string>): string {
+  const firstField = header.split("|")[0]?.trim().split(/\s+/)[0] ?? "";
+  const sanitized = firstField.replace(/[^A-Za-z0-9_.-]/g, "");
+  const token = sanitized || DEFAULT_GENE_NAME_BASE;
+
+  let candidate = token;
+  for (let n = 2; used.has(candidate); n++) candidate = `${token}_${n}`;
+  used.add(candidate);
+  return candidate;
+}
+
 // DNA to protein translation table
 const codonTable: Record<string, string> = {
   TTT: "F",
@@ -322,34 +350,6 @@ const codonTable: Record<string, string> = {
  * @param dnaSequence - The DNA sequence to translate
  * @returns The translated protein sequence
  */
-/**
- * Reduce a FASTA header to a token usable as a repseqio gene name.
- *
- * repseqio addresses each gene as the fragment of a `file://<file>#<geneName>` URI, so a
- * gene name may only contain characters that are legal in a URI fragment. FASTA headers
- * routinely carry a descriptive tail after the identifier, which — appended verbatim —
- * makes repseqio fail with `URISyntaxException: Illegal character in fragment`, several
- * layers below the UI and long after this validation has reported success.
- *
- * Keeps the first whitespace-delimited field ahead of any `|`, drops characters outside
- * `[A-Za-z0-9_.-]`, and appends a counter when two headers reduce to the same token, so
- * distinct records can never collapse onto one gene name.
- *
- * A header can sanitize away entirely — punctuation only, or a non-Latin script. Those
- * fall back to `DEFAULT_GENE_NAME_BASE` and go through the same counter, because two
- * unusable headers are exactly as capable of colliding as two similar ones.
- */
-function uniqueGeneNameToken(header: string, used: Set<string>): string {
-  const firstField = header.split("|")[0]?.trim().split(/\s+/)[0] ?? "";
-  const sanitized = firstField.replace(/[^A-Za-z0-9_.-]/g, "");
-  const token = sanitized || DEFAULT_GENE_NAME_BASE;
-
-  let candidate = token;
-  for (let n = 2; used.has(candidate); n++) candidate = `${token}_${n}`;
-  used.add(candidate);
-  return candidate;
-}
-
 function translateDNAToProtein(dnaSequence: string): string {
   const cleanSequence = dnaSequence.toUpperCase().replace(/\s/g, "");
   let proteinSequence = "";

--- a/ui/src/utils/parseFasta.ts
+++ b/ui/src/utils/parseFasta.ts
@@ -1,3 +1,6 @@
+/** Gene-name stem used when a record has no header, or none that survives sanitizing. */
+const DEFAULT_GENE_NAME_BASE = "ref";
+
 export interface FastaParseResult {
   isValid: boolean;
   error?: string;
@@ -194,8 +197,8 @@ export function parseFasta(
       const splitPoint = Math.floor((cleanSequence.length * 2) / 3);
       const vGeneSequence = sequenceWithoutN.substring(0, splitPoint);
       const jGeneSequence = sequenceWithoutN.substring(splitPoint);
-      const vGeneHeader = headerRoot ? `${headerRoot}_Vgene` : "ref_Vgene";
-      const jGeneHeader = headerRoot ? `${headerRoot}_Jgene` : "ref_Jgene";
+      const vGeneHeader = `${headerRoot || DEFAULT_GENE_NAME_BASE}_Vgene`;
+      const jGeneHeader = `${headerRoot || DEFAULT_GENE_NAME_BASE}_Jgene`;
       vGeneParts.push(`>${vGeneHeader}\n${vGeneSequence}`);
       jGeneParts.push(`>${jGeneHeader}\n${jGeneSequence}`);
       if (header) headers.push(header);
@@ -220,14 +223,14 @@ export function parseFasta(
     // Use sequenceWithoutN (N→A) since repseqio fromFasta rejects wildcard nucleotides
     const vGeneEndNucleotides = cdr3StartNucleotides + cdr3HalfLengthNucleotides;
     const vGeneSequence = sequenceWithoutN.substring(0, vGeneEndNucleotides);
-    const vGeneHeader = headerRoot ? `${headerRoot}_Vgene` : "ref_Vgene";
+    const vGeneHeader = `${headerRoot || DEFAULT_GENE_NAME_BASE}_Vgene`;
     const vGene = `>${vGeneHeader}\n${vGeneSequence}`;
 
     // J gene: from second half of CDR3 to sequence end
     // Use sequenceWithoutN (N→A) since repseqio fromFasta rejects wildcard nucleotides
     const jGeneStartNucleotides = cdr3StartNucleotides + cdr3HalfLengthNucleotides;
     const jGeneSequence = sequenceWithoutN.substring(jGeneStartNucleotides);
-    const jGeneHeader = headerRoot ? `${headerRoot}_Jgene` : "ref_Jgene";
+    const jGeneHeader = `${headerRoot || DEFAULT_GENE_NAME_BASE}_Jgene`;
     const jGene = `>${jGeneHeader}\n${jGeneSequence}`;
 
     vGeneParts.push(vGene);
@@ -329,14 +332,17 @@ const codonTable: Record<string, string> = {
  * layers below the UI and long after this validation has reported success.
  *
  * Keeps the first whitespace-delimited field ahead of any `|`, drops characters outside
- * `[A-Za-z0-9_.-]`, and appends a counter when two headers reduce to the same token.
- * Returns an empty string when nothing usable remains, so the caller falls back to its
- * own default gene name.
+ * `[A-Za-z0-9_.-]`, and appends a counter when two headers reduce to the same token, so
+ * distinct records can never collapse onto one gene name.
+ *
+ * A header can sanitize away entirely — punctuation only, or a non-Latin script. Those
+ * fall back to `DEFAULT_GENE_NAME_BASE` and go through the same counter, because two
+ * unusable headers are exactly as capable of colliding as two similar ones.
  */
 function uniqueGeneNameToken(header: string, used: Set<string>): string {
   const firstField = header.split("|")[0]?.trim().split(/\s+/)[0] ?? "";
-  const token = firstField.replace(/[^A-Za-z0-9_.-]/g, "");
-  if (!token) return "";
+  const sanitized = firstField.replace(/[^A-Za-z0-9_.-]/g, "");
+  const token = sanitized || DEFAULT_GENE_NAME_BASE;
 
   let candidate = token;
   for (let n = 2; used.has(candidate); n++) candidate = `${token}_${n}`;

--- a/ui/src/utils/parseFasta.ts
+++ b/ui/src/utils/parseFasta.ts
@@ -121,6 +121,7 @@ export function parseFasta(
   const vGeneParts: string[] = [];
   const jGeneParts: string[] = [];
   const headers: string[] = [];
+  const usedGeneNames = new Set<string>();
 
   // Validate each record
   for (const [i, record] of records.entries()) {
@@ -133,7 +134,7 @@ export function parseFasta(
     }
 
     const recordIdentifier = header ? `Record "${header}"` : `Record ${i + 1}`;
-    const headerRoot = header ? header.split("|")[0]?.trim() : "";
+    const headerRoot = header ? uniqueGeneNameToken(header, usedGeneNames) : "";
 
     // Clean the sequence (remove whitespace, convert to uppercase, and normalize IUPAC wildcards to N)
     const cleanSequence = sequence
@@ -318,6 +319,31 @@ const codonTable: Record<string, string> = {
  * @param dnaSequence - The DNA sequence to translate
  * @returns The translated protein sequence
  */
+/**
+ * Reduce a FASTA header to a token usable as a repseqio gene name.
+ *
+ * repseqio addresses each gene as the fragment of a `file://<file>#<geneName>` URI, so a
+ * gene name may only contain characters that are legal in a URI fragment. FASTA headers
+ * routinely carry a descriptive tail after the identifier, which — appended verbatim —
+ * makes repseqio fail with `URISyntaxException: Illegal character in fragment`, several
+ * layers below the UI and long after this validation has reported success.
+ *
+ * Keeps the first whitespace-delimited field ahead of any `|`, drops characters outside
+ * `[A-Za-z0-9_.-]`, and appends a counter when two headers reduce to the same token.
+ * Returns an empty string when nothing usable remains, so the caller falls back to its
+ * own default gene name.
+ */
+function uniqueGeneNameToken(header: string, used: Set<string>): string {
+  const firstField = header.split("|")[0]?.trim().split(/\s+/)[0] ?? "";
+  const token = firstField.replace(/[^A-Za-z0-9_.-]/g, "");
+  if (!token) return "";
+
+  let candidate = token;
+  for (let n = 2; used.has(candidate); n++) candidate = `${token}_${n}`;
+  used.add(candidate);
+  return candidate;
+}
+
 function translateDNAToProtein(dnaSequence: string): string {
   const cleanSequence = dnaSequence.toUpperCase().replace(/\s/g, "");
   let proteinSequence = "";


### PR DESCRIPTION
Two independent defects in `ui/src/utils/parseFasta.ts` each made a reference FASTA fail. Both hit `2026-07-synthetic-nanobody-abaumannii`, the one study in `platforma-studies-library` whose README prescribes this block. Both are fixed here, each with tests.

## 1. A descriptive header became an illegal gene name

repseqio addresses each gene as the fragment of a `file://<file>#<geneName>` URI, so spaces, `(`, `)`, `,` and `;` break it. Gene names come from the FASTA header, and the old derivation stripped nothing beyond a `|` split:

```ts
const headerRoot = header ? header.split("|")[0]?.trim() : "";
```

A header without `|` therefore passed through whole. In the case that surfaced this, the derived name ran **275 characters** and repseqio died:

```
java.net.URISyntaxException: Illegal character in fragment at index 27:
file://vGene.fasta#S1-F4_VH parental anti-CD98hc heavy variable domain, nucleotide (recovered by ...
```

Index 27 is the space after `S1-F4_VH`; each punctuation mark would have failed too. The worst part was where it surfaced: `parseFasta` had already returned `isValid: true`, so the user got no input feedback — just a Java stack trace from a container step several layers down.

`uniqueGeneNameToken()` now reduces a header to its first whitespace-delimited field ahead of any `|`, drops characters outside `[A-Za-z0-9_.-]`, and falls back to a `ref` stem. It also appends a counter on collision, because truncating alone would merge `>gene_a first` and `>gene_a second` into one gene name — trading a loud failure for a quiet wrong answer. Fallback names share that counter, so several records whose headers all sanitize away stay distinct. The full header still drives display and record selection; only the derived gene name changes.

## 2. The CDR3 search offset hid the cysteine that matters

`parseFasta` locates the CDR3 with a cysteine-anchored regex applied from a fixed offset:

```ts
const searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
```

The offset skips the conserved FR1 cysteine near residue 20, which would otherwise anchor the V/J split at the start of the domain. That works for a reference starting at the domain N-terminus. A reference covering only the amplified region starts mid-FR1, which pulls its CDR3 cysteine ahead of the offset and hides it.

The nanobody parental clone is exactly that shape — it starts at `…RLSCAAS`, 303 nt translating to 101 aa with the CDR3 cysteine at residue 78, two ahead of the offset. Both callers handled it badly:

- **`SettingsPanel.vue:95`** parses strictly and rejected it: `Translated sequence does not contain CDR3 after position 80`.
- **`BuildLibraryPanel.vue:174`** passes `lenient: true`, which reported `isValid: true` and split V from J at two-thirds of the sequence. The real boundary is **253 nt**; the guess gives **202** — 51 nt of V handed to the J gene, with nothing in the UI to say the boundary was guessed.

### Escalation, not derivation

Deriving the offset from the sequence is the tempting fix and the wrong one. Measured across all 137 nucleotide references in `platforma-studies-library`:

| candidate | failures /137 | changes behaviour on currently-working records |
|---|---|---|
| current (`offset 80`) | 1 | — |
| search from 0 (drop the offset) | 0 | **~half** — anchors on the FR1 cysteine (S1-F4: residue 21 vs 95; CR9114: 28 vs 102) |
| take the *last* match | 0 | **~90** — an scFv carries two domains and so two CDR3s; the last match takes the second |
| search after the first cysteine | 0 | 2 — fixes the nanobody, regresses `KU641085.1`, which has no FR1 cysteine |
| **keep 80, retry from 0 on a miss** | **0** | **1 — the currently-broken one** |

The offset resolves the FR1 cysteine correctly for 136 of 137, so it stays as the primary search and the whole translation is searched only when it finds nothing. The rejection message drops its mention of the offset, since by then the whole sequence has been searched.

## Tests

`ui` had a `vitest.config.mts` but no `test` script and no vitest dependency, so nothing in the package ever ran. This adds `vitest` from the workspace catalog, a `test` script, and `ui/src/utils/parseFasta.test.ts` — 18 tests through the public `parseFasta` / `parseFastaRecords` API rather than the private helpers. `turbo` already defines a `test` task, so `ui` now participates in it.

Gene-name tests were mutation-checked: reverting the call site to `header.split("|")[0]?.trim()` fails exactly five and passes the other nine.

The CDR3 tests were written first, and the two red ones were observed failing before the fix existed:

| test | pre-fix |
|---|---|
| locates a CDR3 that sits ahead of the search offset | fails — `isValid: false` |
| splits a mid-FR1 reference at its real boundary in lenient mode | fails — V is 202 nt, not 253 |
| anchors on the CDR3 cysteine rather than the FR1 cysteine | passes (guard) |
| anchors on the first CDR3 when one record carries two variable domains | passes (guard) |

The two guards pass before and after by design, and they are the point rather than an afterthought: the offset looks arbitrary and invites removal, and each guard fails against three of the four rejected candidates above.

Two tests encode *why* each bug existed. The URI-fragment test asserts the derived name contains nothing outside `[A-Za-z0-9_.-]` — repseqio's requirement, and the thing nothing checked before. An earlier revision asserted it by constructing `new URL("file://vGene.fasta#" + geneName)` and expecting no throw. That was vacuous and is gone: JS `URL` is WHATWG and percent-encodes illegal fragment characters rather than rejecting them, so it accepted every input including the original 275-character header. repseqio parses with Java's `java.net.URI` (RFC 2396), which is strict. The character-set assertion is what holds the line.

Fixtures are real references — the 375 nt S1-F4 parental VH, the 303 nt nanobody parental clone, and `KU641040.1` from the macaque anti-SIV gp140 panel — so the tests exercise the genuine path rather than synthetic sequences that might skip it.

## Verification

**Regression sweep.** Ran the patched `parseFasta` over every nucleotide reference FASTA in the studies library and diffed the V boundary against pre-change behaviour: **136 records, 136 identical boundaries, zero rejections before or after.** The nanobody is the only behaviour change; it ships in its study README rather than a `.fasta`, so unit tests cover it.

**End to end.** Ran against a remote backend with the published block and a dev build of this branch side by side in one project — same dataset, same settings (IGHeavy, VDJRegion, FASTA-sequence mode, the 303 nt clone).

| | published | this branch |
|---|---|---|
| reference accepted | no | yes — V 253 nt / J 50 nt |
| `referenceLibrary` | errored | built (1224 B) |
| samples completed | 0 | 3/3 |
| align + assemble reports | none | txt + json for all three |
| QC | errored | 3 files |
| clonotype tables | none | 121 MB / 242 MB / 520 MB |
| `pt` | errored | ok |

The published block fails in the workflow, with no mention of the reference:

```
tengo template error: type schema validation error:
js "<undefined>" does not fit any of the following rules: ["or", "string", "bytes", …]
@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow:repseqio-library:17:22
```

The V and J lengths the running app derives — 253 and 50 — match what `parseFasta.test.ts` asserts, so the unit tests and the live block agree on the boundary. The library builds at the exact step where the published block dies, and the study's three samples (the *A. baumannii* target plus the GFP and *V. cholerae* controls) all complete alignment and assembly.

The dev block errors one output, `prerunLibrary`, and it is not from this change:

- `prerun.tpl.tengo:11` guards on `referenceInputMode == "buildLibrary" && !is_undefined(args.buildLibraryVGenes)`. This run is `fastaSequence` with `buildLibraryVGenes` absent, and the published block in the same mode reports `prerunLibrary` ok with no value, so the guard skips as intended.
- The failing nodes in the error chain were allocated during the published block's failed run, and the poisoned node is a result-pool export (`clones.clonotypeProperties/aggregates/IGHeavy/aa-annotation-Segments-vdjregion`). The dev block sits last in the project, so that failed block's exports are in its staging context.
- This change touches only `parseFasta.ts` and cannot reach the workflow.

That is inference from resource ids and the guard, not proof. Confirming it means making the published block healthy and re-checking — worth doing before merge, but it does not bear on either fix.

Also checked: `pnpm run build:dev-no-software` (9/9), `ui` `pnpm run check`, and `ui` `pnpm run test` (18/18).

## Lockfile churn

Adding vitest to `ui` re-resolves the vitest subtree, so `pnpm-lock.yaml` shows 19 insertions and 156 deletions. The churn is confined to `@vitest/*`, `chai`, `tinyrainbow`, `tinyglobby`, `picomatch`, `postcss`, `nanoid` and `vite`, and the net direction is consolidation as duplicate vitest resolutions collapse into one set.

Two resolutions genuinely move, both inside `@platforma-sdk/test`: its `vite` peer goes `7.3.0` → `8.0.16` (and `lightningcss` gives way to `esbuild` there), and the private `vitest@4.1.8` is dropped, with `@vitest/coverage-istanbul@4.1.8` re-binding onto `vitest@4.0.18`.

Both affect the block-test toolchain rather than the shipped UI bundle. The version block tests execute under is unchanged: `test/` already declared `vitest: catalog:` (→ `4.0.18`), so it is 4.0.18 before and after, and `test/` `ts-builder check` still passes. The `vite` major is the part worth a reviewer's eye, which is why it is called out here rather than left in the diff.

A plain `pnpm install --no-frozen-lockfile` on `main` leaves the lockfile untouched, so this drift comes from the vitest addition rather than pre-existing staleness.

## Not included

**The lenient path still guesses silently.** The two-thirds fallback is now near-unreachable for a real reference, but when reached it still reports `isValid: true` without saying the boundary was estimated. Surfacing that needs a warning channel through `FastaParseResult` and a banner in `BuildLibraryPanel.vue`, which today has only `:error` on the file input.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes FASTA-derived gene-name collisions and expands CDR3 detection for references beginning before the fixed search offset, with regression tests and UI test-runner integration.
- **FASTA header** — The descriptive identifier line preceding a sequence; derivation now uses its first whitespace-delimited field before `|`.
- **Gene-name token** — The sanitized stem used for generated V/J gene names; it is restricted to `[A-Za-z0-9_.-]`, falls back to `ref`, and receives a counter when duplicated.
- **CDR3** — The cysteine-anchored complementarity-determining region used to split V and J sequences; detection now retries across the full translation when the offset search misses.
- **Search offset** — The 80-amino-acid starting point that avoids the FR1 cysteine; it remains the primary search boundary but is no longer the only one.
- **Lenient parsing** — Parsing that estimates a V/J boundary when no CDR3 is found; valid early CDR3s are now detected before this fallback.
- Adds 18 public-API regression tests and configures the UI package to run Vitest.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/utils/parseFasta.ts | Sanitizes and uniquifies generated gene names and adds a full-translation fallback for CDR3 detection; the previously reported fallback collision is fixed. |
| ui/src/utils/parseFasta.test.ts | Adds regression coverage for legal and unique gene names, fallback collisions, early CDR3s, FR1 anchoring, and multi-domain references. |
| ui/package.json | Adds the UI Vitest dependency and test script. |
| pnpm-lock.yaml | Resolves the added UI Vitest dependency and consolidates related test-toolchain packages. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Parse FASTA record] --> B[Sanitize and uniquify gene-name token]
  B --> C[Translate nucleotide sequence]
  C --> D[Search for CDR3 from residue 80]
  D -->|Match| E[Split V and J at CDR3 midpoint]
  D -->|No match| F[Retry across full translation]
  F -->|Match| E
  F -->|No match, strict| G[Return validation error]
  F -->|No match, lenient| H[Use two-thirds estimated boundary]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge pull request #94 from platforma-op..."](https://github.com/platforma-open/mixcr-amplicon-alignment/commit/b66e4a1250c5c6b112b1b42528af31edbf23d333) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50383938)</sub>

<!-- /greptile_comment -->