### PR TITLE
MILAB-6739: find the CDR3 when a reference begins mid-FR1

### DIFF
--- a/.changeset/cdr3-search-offset-escalation.md
+++ b/.changeset/cdr3-search-offset-escalation.md
@@ -1,0 +1,17 @@
+---
+"@platforma-open/milaboratories.mixcr-amplicon-alignment.ui": patch
+---
+
+A reference that begins mid-FR1 no longer loses its CDR3.
+
+The CDR3 is located with a cysteine-anchored regex applied from a fixed offset of 80
+residues, which exists to skip the conserved FR1 cysteine. A reference covering only the
+amplified region rather than the full domain begins mid-FR1, which pulls its CDR3
+cysteine ahead of that offset and hides it. Strict parsing then rejected the reference
+outright; lenient parsing reported success and split V from J at two-thirds of the
+sequence — a guess that for the synthetic-nanobody reference put the boundary at 202 nt
+instead of 253, with nothing shown in the UI to say the boundary was guessed.
+
+The offset is now the primary search rather than the only one: when it finds nothing,
+the whole translated sequence is searched before giving up. Every nucleotide reference
+that resolved before resolves to the identical boundary.

--- a/ui/src/utils/parseFasta.test.ts
+++ b/ui/src/utils/parseFasta.test.ts
@@ -16,6 +16,42 @@ const VH_375NT = [
   "GTGACCGTGAGCTCT",
 ].join("\n");
 
+/**
+ * The synthetic nanobody parental clone from `2026-07-synthetic-nanobody-abaumannii`,
+ * 303 nt. This is the amplified region, so it begins mid-FR1 at `…RLSCAAS` rather than
+ * at the domain N-terminus: 101 aa with the conserved CDR3 cysteine at residue 78, ahead
+ * of the search offset. `N` marks a randomized CDR position (CDR1/CDR2/CDR3 = 7/7/9 aa).
+ */
+const VHH_303NT = [
+  "CGTTTGTCTTGTGCTGCGTCCGGCNNNNNNNNNNNNNNNNNNNNNATGGGGTGGTTTCGC",
+  "CAGGCACCTGGCAAAGAACGTGAATTTGTTGCAGCAATTAGTNNNNNNNNNNNNNNNNNN",
+  "NNNTACTACGCAGATTCCGTTAAGGGACGCTTCACAATTTCGCGCGACAATGCAAAAAAT",
+  "ACCGTGTATTTACAAATGAATTCGTTGAAGCCGGAAGACACTGCGACTTATTATTGTGCG",
+  "NNNNNNNNNNNNNNNNNNNNNNNNNNNTATTGGGGACAAGGCACACAAGTCACGGTCTCC",
+  "GTG",
+].join("\n");
+
+/**
+ * `KU641040.1` from the macaque anti-SIV gp140 panel, 738 nt. A single-chain Fv, so one
+ * record carries two variable domains and therefore two CDR3s — the VL's at residue 88
+ * and the VH's at 212. The block resolves this to the first CDR3 past the offset.
+ */
+const SCFV_738NT = [
+  "ATGCTGACTCAGCCCCACTCTGTGTCGGGGTCTCCGGGGCAGACGGTCACCATCTCCTGC",
+  "ACCCGCAGCAGTGGCTACATTGGCAGCAACTCTGTGTACTGGTACCAGCAGCGGCCGGGC",
+  "AGCGCCCCCACCACTGTGATTTACAAAGATAATCAAAGACCCTCTGGGATCCCTGATCGG",
+  "TTCTCTGGCTCCATCGACAGCTCCTCCAACTCTGCCTCCCTCACCATCTCTGGACTGAAG",
+  "TCTGAGGACGAGGCTGACTACTACTGTCAGTCTTATGACAGCACTTATGATGTGTTTTTC",
+  "GGAGGAGGCACCAAGCTGACCGTCCTAGGCGGTGGTTCCTCTAGATCTTCCGAGGTGCAG",
+  "CTGGTGCAGTCTGGGACTGAGGTGAGGAAGCCTGGGGCCTCAGTGAAGGTTTCCTGCCAG",
+  "GCTTCTGGCATCAGCTTCGACAGATATGCTCTCACCTGGGTGCGACAGGTCCCTGGACAA",
+  "GGGCTTGAGTGGATGGGATCGATCATCCCTCTTGCTAGCATGACAAAGTACGCAGAGAAG",
+  "TTCCAGGGCAGAGTCACGATAACCGCGGATACGTCCAGAGGGACAGCCTACATGGAGCTG",
+  "AGTAGCCTGACATCTGAGGACACGGCCGTTTATTATTGTGCGAGACCCGGGGACGACAGT",
+  "GGGGCCTTTGACCTCTGGGGCCAGGGAGCCCTGGTCACCGTCTCCTCAGCCTCCACCAAG",
+  "GGCCCATCGGTCACTAGT",
+].join("\n");
+
 /** The header of that reference as the studies library actually ships it. */
 const DESCRIPTIVE_HEADER =
   "S1-F4_VH parental anti-CD98hc heavy variable domain, nucleotide (recovered by " +
@@ -30,6 +66,11 @@ function fasta(...records: [header: string, sequence: string][]): string {
 /** First line of a single-record FASTA string, without the leading ">". */
 function geneName(fastaString: string | undefined): string {
   return (fastaString ?? "").split("\n")[0]?.replace(/^>/, "") ?? "";
+}
+
+/** Sequence body of a single-record V or J FASTA string, without the header line. */
+function geneSequence(fastaString: string | undefined): string {
+  return (fastaString ?? "").split("\n").slice(1).join("");
 }
 
 function geneNames(fastaString: string | undefined): string[] {
@@ -163,6 +204,56 @@ describe("parseFasta validation", () => {
   it("reports an empty FASTA", () => {
     expect(parseFasta("").isValid).toBe(false);
     expect(parseFasta("   ").error).toBe("FASTA content is empty");
+  });
+});
+
+describe("parseFasta CDR3 location", () => {
+  // The two tests below pin behaviour that already holds. They exist because the search
+  // offset looks arbitrary and invites removal: across the 137 nucleotide references in
+  // platforma-studies-library, searching the whole translated sequence instead anchors on
+  // the FR1 cysteine in roughly half of them, and anchoring on the last match moves the
+  // boundary in about ninety. Whatever finds the CDR3 has to keep these two intact.
+
+  it("anchors on the CDR3 cysteine rather than the FR1 cysteine", () => {
+    const result = parseFasta(fasta(["s1f4", VH_375NT]));
+
+    expect(result.isValid).toBe(true);
+    // S1-F4 carries cysteines at residues 21 (FR1) and 95 (CDR3). Anchoring on 21 would
+    // cut V at 85 nt and hand the remaining 290 nt — nearly the whole domain — to J.
+    expect(geneSequence(result.vGenes)).toHaveLength(315);
+    expect(geneSequence(result.jGenes)).toHaveLength(60);
+  });
+
+  it("anchors on the first CDR3 when one record carries two variable domains", () => {
+    const result = parseFasta(fasta(["scfv", SCFV_738NT]));
+
+    expect(result.isValid).toBe(true);
+    // An scFv has a CDR3 per domain — here at residues 88 and 212, the light chain first.
+    // The boundary belongs to the first; taking the last would move V by 372 nt.
+    expect(geneSequence(result.vGenes)).toHaveLength(295);
+    expect(geneSequence(result.jGenes)).toHaveLength(443);
+  });
+
+  // A reference covering only the amplified region starts mid-FR1, which pulls its CDR3
+  // cysteine ahead of the offset. The offset then hides the one cysteine that matters.
+  it("locates a CDR3 that sits ahead of the search offset", () => {
+    const result = parseFasta(fasta(["nanobody", VHH_303NT]));
+
+    expect(result.isValid).toBe(true);
+    expect(geneSequence(result.vGenes)).toHaveLength(253);
+    expect(geneSequence(result.jGenes)).toHaveLength(50);
+  });
+
+  // The lenient path is the one that reaches a user: BuildLibraryPanel parses with
+  // `lenient: true`, and on a miss it splits at two-thirds of the sequence and reports
+  // success. For this reference that guess puts the boundary at 202 nt instead of 253 —
+  // 51 nt of V handed to the J gene, with nothing shown in the UI to say so.
+  it("splits a mid-FR1 reference at its real boundary in lenient mode", () => {
+    const result = parseFasta(fasta(["nanobody", VHH_303NT]), undefined, true);
+
+    expect(result.isValid).toBe(true);
+    expect(geneSequence(result.vGenes)).toHaveLength(253);
+    expect(geneSequence(result.jGenes)).toHaveLength(50);
   });
 });
 

--- a/ui/src/utils/parseFasta.ts
+++ b/ui/src/utils/parseFasta.ts
@@ -183,14 +183,24 @@ export function parseFasta(
     const validationRegex =
       /C([ACDEFGHIKLMNPQRSTVWYX]{4,50}[FWYLIX])[ACDEFGHIKLMNPQRSTVWYX]{0,5}G[ACDEFGHIKLMNPQRSTVWYX]G/;
 
-    // Only search from position 80 onwards (240 nucleotides)
-    const searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
-    const sequenceToSearch = translatedSequence.substring(searchStartPosition);
+    // The offset exists to skip the conserved FR1 cysteine, which sits near residue 20 and
+    // would otherwise anchor the split at the start of the domain. That holds for a
+    // reference beginning at the domain N-terminus; one covering only the amplified region
+    // begins mid-FR1, which pulls its CDR3 cysteine ahead of the offset and hides it.
+    //
+    // So escalate rather than derive: keep the offset as the primary search — it resolves
+    // the FR1 cysteine correctly for all but one of the nucleotide references we have —
+    // and widen to the whole translation only when it finds nothing.
+    let searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
+    let match = validationRegex.exec(translatedSequence.substring(searchStartPosition));
+    if (!match) {
+      searchStartPosition = 0;
+      match = validationRegex.exec(translatedSequence);
+    }
 
-    const match = validationRegex.exec(sequenceToSearch);
     if (!match) {
       if (!lenient) {
-        const error = `${recordIdentifier}: Translated sequence does not contain CDR3 after position ${searchStartPosition}`;
+        const error = `${recordIdentifier}: Translated sequence does not contain a CDR3`;
         return { isValid: false, error };
       }
       // In lenient mode, split at 2/3 of the sequence as a rough V/J boundary estimate


### PR DESCRIPTION
> Stacked on #93 — this branch targets `MILAB-6731_fasta-gene-name-sanitize`, not `main`, because it needs the vitest harness that PR introduces. Review #93 first; retarget to `main` once it merges.

## What

`ui/src/utils/parseFasta.ts` locates the CDR3 with a cysteine-anchored regex, but only from a fixed offset:

```ts
const searchStartPosition = 80; // 240 nucleotides / 3 = 80 amino acids
const sequenceToSearch = translatedSequence.substring(searchStartPosition);
```

The offset exists to skip the conserved FR1 cysteine, which sits near residue 20 and would otherwise anchor the V/J split at the start of the domain. That holds for a reference beginning at the domain N-terminus. A reference covering only the *amplified region* begins mid-FR1, which pulls its CDR3 cysteine ahead of the offset and hides it.

`2026-07-synthetic-nanobody-abaumannii` is such a reference, and it is the study whose README prescribes this block. Its parental clone starts at `…RLSCAAS`: **303 nt → 101 aa, CDR3 cysteine at residue 78** — two ahead of the offset.

Neither caller handles it well:

- **`SettingsPanel.vue:95`** parses strictly and rejects with `Translated sequence does not contain CDR3 after position 80`. The study's own prescribed input is unusable.
- **`BuildLibraryPanel.vue:174`** passes `lenient: true`, which reports `isValid: true` and splits V from J at two-thirds of the sequence. The real boundary is **253 nt**; the guess gives **202** — 51 nt of V handed to the J gene, with nothing in the UI to say the boundary was guessed.

## Why escalation, not derivation

Deriving the offset from the sequence is the tempting fix and the wrong one. Measured against every nucleotide reference FASTA in `platforma-studies-library` (137 records):

| candidate | failures /137 | changes behaviour on currently-working records |
|---|---|---|
| current (`offset 80`) | 1 | — |
| search from 0 (drop the offset) | 0 | **~half** — anchors on the FR1 cysteine (S1-F4: residue 21 vs 95; CR9114: 28 vs 102) |
| take the *last* match | 0 | **~90** — an scFv carries two variable domains and so two CDR3s; the last match moves the boundary to the second |
| search after the first cysteine | 0 | 2 — fixes the nanobody but regresses `KU641085.1`, which has no FR1 cysteine at all |
| **keep 80, retry from 0 on a miss** | **0** | **1 — the currently-broken one** |

The offset resolves the FR1 cysteine correctly for 136 of 137. So it stays as the primary search, and the whole translation is searched only when it finds nothing.

The rejection message drops its reference to the offset, since by the time it is reached the whole sequence has been searched.

## Verification

### Regression sweep

Ran the patched `parseFasta` over every nucleotide reference FASTA in the studies library and diffed the V boundary against pre-change behaviour:

**136 records compared, 136 identical boundaries, zero rejections before or after.** The nanobody reference is the only behaviour change; it ships in its study README rather than a `.fasta`, so it is covered by unit test instead.

`pnpm run build:dev-no-software` (9/9), `ui` `pnpm run check`, and `ui` `pnpm run test` (18/18) all pass.

### End to end

Verified against a remote backend on the prescribed study, with the published block and a dev build of this branch side by side in one project, same dataset and same settings (IGHeavy, VDJRegion, FASTA-sequence mode, the 303 nt parental clone).

**Published block** — reproduces the defect:

- the UI rejects the reference: `Record "nanobody_parental": Translated sequence does not contain CDR3 after position 80`
- `vGenes` / `jGenes` stay `null`
- running anyway fails, with `done`, `logs`, `pt`, `qc`, `referenceLibrary`, `reports`, `rawTsvs` and `progress` all errored:

```
tengo template error: type schema validation error:
js "<undefined>" does not fit any of the following rules: ["or", "string", "bytes", …]
@platforma-open/milaboratories.mixcr-amplicon-alignment.workflow:repseqio-library:17:22
```

**This branch** — same input, same settings:

| | published | this branch |
|---|---|---|
| reference accepted | no | yes — V 253 nt / J 50 nt |
| `referenceLibrary` | errored | built (1224 B) |
| samples completed | 0 | 3/3 |
| align + assemble reports | none | txt + json for all three |
| QC | errored | 3 files |
| clonotype tables | none | 121 MB / 242 MB / 520 MB |
| `pt` | errored | ok |

The V and J lengths the running app derives — 253 and 50 — are the same numbers `parseFasta.test.ts` asserts, so the unit tests and the live block agree. The library builds at exactly the step where the published block dies, and the study's three samples (the *A. baumannii* target plus the GFP and *V. cholerae* controls) all complete alignment and assembly.

One output of the dev block does error: `prerunLibrary`. It is not caused by this change, which touches only `parseFasta.ts` and cannot reach the workflow:

- `prerun.tpl.tengo:11` guards on `referenceInputMode == "buildLibrary" && !is_undefined(args.buildLibraryVGenes)`. This run is `fastaSequence` with `buildLibraryVGenes` absent, and the published block in the same mode reports `prerunLibrary` ok with no value — so the guard skips as intended.
- the failing nodes in the error chain were allocated during the *published* block's failed run, not this block's; the poisoned node is a result-pool export (`clones.clonotypeProperties/aggregates/IGHeavy/aa-annotation-Segments-vdjregion`).
- the dev block sits last in the project, so the failed block's exports are in its staging context.

That is inference from resource ids and the guard rather than proof. Confirming it means making the published block healthy and re-checking, which is worth doing before merge but does not bear on the fix.

## Tests

Written first, and the two red ones observed failing before the fix existed.

| test | pre-fix |
|---|---|
| locates a CDR3 that sits ahead of the search offset | fails — `isValid: false` |
| splits a mid-FR1 reference at its real boundary in lenient mode | fails — V is 202 nt, not 253 |
| anchors on the CDR3 cysteine rather than the FR1 cysteine | passes (guard) |
| anchors on the first CDR3 when one record carries two variable domains | passes (guard) |

The strict failure was checked to be the offset itself — `Translated sequence does not contain CDR3 after position 80` — rather than the length or translation checks that precede it.

The two guards pass before and after by design. They are the point of the change rather than an afterthought: the offset looks arbitrary and invites removal, and each guard fails against three of the four rejected candidates above. S1-F4 pins that a full-length domain still anchors at residue 95 and not 21; the scFv pins that a two-domain record still takes the first CDR3 and not the second.

Fixtures are the real references — the 303 nt nanobody parental clone and `KU641040.1` from the macaque anti-SIV gp140 panel — so the tests exercise the genuine path rather than synthetic sequences that might skip it.

## Not included

**The lenient path still guesses silently.** With this change the two-thirds fallback becomes near-unreachable for a real reference, but when it is reached it still reports `isValid: true` with no indication the boundary was estimated. Surfacing that needs a warning channel through `FastaParseResult` and a banner in `BuildLibraryPanel.vue`, which today has no warning slot — only `:error` on the file input.

**The model does not gate `canRun` on the reference.** Surfaced by the end-to-end run above: with `vGenes` and `jGenes` both `null`, the block still reported `canRun: true` and `inputsValid: true`. A user who ignores the red validation text and presses Run gets the `repseqio-library:17:22` Tengo type error quoted above, which names neither the reference nor the field that is missing. This change removes the reason that state arises for mid-FR1 references, but not the state itself — any other rejected reference still reaches it. Fixing it belongs in the block model, not here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the offset-based CDR3 search while adding a whole-translation fallback for references beginning mid-FR1. Regression tests cover the newly supported nanobody reference and guard existing full-domain and multi-domain behavior.

- Changes CDR3 matching from a single offset search to an offset-first search followed by a full-sequence retry.
- Updates the strict validation message after both search ranges have been exhausted.
- Adds strict and lenient regression coverage plus guards against selecting FR1 or a second variable domain.
- Adds a patch changeset documenting the corrected behavior.
- Important touched terms:
  - **CDR3**: Complementarity-determining region 3, located using a conserved cysteine-anchored amino-acid pattern. The PR allows its anchor to be found before residue 80 when the primary search misses.
  - **FR1**: Framework region 1, which contains an earlier conserved cysteine that must not be mistaken for the CDR3 anchor. The existing offset remains the primary defense against that false boundary.
  - **Search offset**: The residue-80 starting point used for the primary translated-sequence search. It is retained but is no longer the only search range.
  - **Fallback search**: The new retry over the complete translated sequence. It runs only when the offset search finds no match.
  - **Lenient parsing**: Parsing mode that estimates the V/J split when no CDR3 is found. The new fallback makes that estimate unnecessary for the covered mid-FR1 reference, while the existing estimate remains unchanged.
  - **V/J boundary**: The nucleotide split between generated V- and J-gene sequences. The regression fixture now resolves to 253 nt of V and 50 nt of J.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The fallback is reached only after the established offset search misses, retains correct boundary indexing, and is covered by tests for the repaired input and the principal anchoring regressions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/utils/parseFasta.ts | Adds an offset-first, whole-sequence fallback while preserving boundary arithmetic and existing strict/lenient handling. |
| ui/src/utils/parseFasta.test.ts | Adds representative regression tests for mid-FR1, FR1-anchor, multi-domain, and lenient parsing behavior. |
| .changeset/cdr3-search-offset-escalation.md | Documents the user-visible parsing correction and its effect on strict and lenient modes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Translate nucleotide reference] --> B[Search from amino-acid offset 80]
    B -->|Match| C[Calculate V/J boundary]
    B -->|No match| D[Search full translated sequence]
    D -->|Match| C
    D -->|No match, strict| E[Return validation error]
    D -->|No match, lenient| F[Use existing two-thirds estimate]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6739: find the CDR3 when a referen..."](https://github.com/platforma-open/mixcr-amplicon-alignment/commit/3d6c010eb481e892fe0369ff16da3facba5a08d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50773294)</sub>

<!-- /greptile_comment -->